### PR TITLE
Initialize the variable size struct to address compiler warning

### DIFF
--- a/src/wprof.c
+++ b/src/wprof.c
@@ -368,10 +368,12 @@ static void print_exit_summary(struct worker_state *workers, int worker_cnt, str
 	int err;
 	u64 rb_handled_cnt = 0, rb_ignored_cnt = 0;
 	u64 rb_handled_sz = 0, rb_ignored_sz = 0;
-	struct wprof_stats stats_by_cpu[num_cpus] = {};
-	struct wprof_stats stats_by_rb[env.ringbuf_cnt] = {};
+	struct wprof_stats stats_by_cpu[num_cpus];
+	struct wprof_stats stats_by_rb[env.ringbuf_cnt];
 	struct wprof_stats s = {};
 	double dur_s = env.duration_ns / 1000000000.0;
+	memset(stats_by_cpu, 0, sizeof(stats_by_cpu));
+	memset(stats_by_rb, 0, sizeof(stats_by_rb));
 
 	if (!skel)
 		goto skip_prog_stats;


### PR DESCRIPTION
Address compilation error below:

<img width="2162" height="524" alt="image" src="https://github.com/user-attachments/assets/bae1352b-cad2-4b90-8a00-b3a6b9e28fdf" />
