### PR TITLE
Add python function tracer + PyTorch Record Function

### DIFF
--- a/JSON_SCHEMA.md
+++ b/JSON_SCHEMA.md
@@ -37,6 +37,7 @@ The first line contains session metadata. Example:
   "capture_scx": false,
   "capture_cuda": false,
   "capture_pystacks": false,
+  "capture_pytrace": false,
   "stacks": ["timer", "offcpu"],
   "stack_cnt": 42,
   "event_cnt": 100000,
@@ -54,6 +55,7 @@ The first line contains session metadata. Example:
 | `capture_scx`      | bool            | Whether sched-ext events were captured                               |
 | `capture_cuda`     | bool            | Whether CUDA activity was captured                                   |
 | `capture_pystacks` | bool            | Whether Python stack traces were captured                            |
+| `capture_pytrace`   | bool            | Whether Python function tracing was captured                         |
 | `stacks`           | array of string | Stack trace kinds captured (e.g., `["timer","offcpu"]`, `[]` if none)|
 | `stack_cnt`        | int             | Number of stack trace lines that follow (0 if none)                  |
 | `event_cnt`        | int             | Total number of event lines that follow                              |
@@ -632,5 +634,49 @@ the host process that owns the GPU context, not a thread running on the CPU.
   "kind": "stream",
   "stream_id": 7,
   "corr_id": 503
+}
+```
+
+---
+
+### Python function tracing events
+
+These events are emitted when Python function tracing (`-f py-func`) is enabled.
+They represent deterministic function call/return events captured via
+`PyEval_SetProfile`, providing exact function call trees with timestamps.
+
+#### `pytrace_entry` — Python function entry
+
+| Field    | Type   | Description                                |
+|----------|--------|--------------------------------------------|
+| `task`   | task   | Thread entering the function               |
+| `name`   | string | Qualified function name                    |
+| `file`   | string | *(optional)* Source file path              |
+| `lineno` | int    | *(optional)* First line number of function |
+
+```json
+{
+  "ts": 0.500100000,
+  "t": "pytrace_entry",
+  "task": {"tid": 1234, "pid": 1000, "comm": "python3"},
+  "name": "module.MyClass.process",
+  "file": "/app/module.py",
+  "lineno": 42
+}
+```
+
+#### `pytrace_exit` — Python function exit
+
+| Field  | Type   | Description                     |
+|--------|--------|---------------------------------|
+| `task` | task   | Thread returning from function  |
+| `name` | string | Qualified function name         |
+
+```json
+{
+  "ts": 0.500200000,
+  "t": "pytrace_exit",
+  "task": {"tid": 1234, "pid": 1000, "comm": "python3"},
+  "name": "module.MyClass.process"
 }
 ```

--- a/src/Makefile
+++ b/src/Makefile
@@ -56,7 +56,8 @@ INCLUDES := -I$(OUTPUT) -I../include -I../libbpf/include/uapi				\
 CFLAGS ?= -g -O$(if $(DEBUG),0,2) -Wall
 ALL_CFLAGS := $(CFLAGS) $(EXTRA_CFLAGS) -fno-omit-frame-pointer				\
 	      -Wno-c23-extensions -Wno-sign-compare -Wno-format-truncation		\
-	      $(if $(LTO),-flto=auto -ffat-lto-objects) $(PYSTACKS_CFLAGS)
+	      $(if $(LTO),-flto=auto -ffat-lto-objects) $(PYSTACKS_CFLAGS)		\
+	      $(if $(DEBUG),-DDEBUG)
 ALL_LDFLAGS := $(LDFLAGS) $(EXTRA_LDFLAGS) -lrt -ldl -lpthread -lm
 
 # Get Clang's default includes on this system. We'll explicitly add these dirs

--- a/src/Makefile
+++ b/src/Makefile
@@ -186,7 +186,7 @@ WPROF_SRCS := wprof.c utils.c env.c protobuf.c data.c emit.c stacktrace.c pmu.c	
 WPROF_HDRS := wprof.h utils.h env.h protobuf.h data.h emit.h stacktrace.h topology.h pmu.h	\
 	      proc.h requests.h cuda.h inj_common.h inject.h sys.h elf_utils.h cuda_data.h 	\
 	      wprof_types.h demangle.h merge.h wevent.h persist.h		\
-				pystacks.h pyoffsets.h pysym.h pyline.h
+				pystacks.h pyoffsets.h pydisc.h pysym.h pyline.h
 WPROF_OBJS := $(patsubst %.c,$(OUTPUT)/%.o,$(WPROF_SRCS))
 
 WPROFINJ_SRCS := inj_lib.c inj_strset.c inj_hashmap.c inj_cupti.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -183,15 +183,15 @@ WPROF_SRCS := wprof.c utils.c env.c protobuf.c data.c emit.c stacktrace.c pmu.c	
 	      pb_common.c pb_encode.c perfetto_trace.pb.c topology.c proc.c			\
 	      requests.c cuda.c inject.c sys.c elf_utils.c merge.c persist.c			\
 	      cupti_driver_cbid_map.gen.c cupti_runtime_cbid_map.gen.c		\
-				pystacks.c pydisc.c pysym.c pyline.c
+				pystacks.c pydisc.c pysym.c pyline.c pytrace.c
 WPROF_HDRS := wprof.h utils.h env.h protobuf.h data.h emit.h stacktrace.h topology.h pmu.h	\
 	      proc.h requests.h cuda.h inj_common.h inject.h sys.h elf_utils.h cuda_data.h 	\
 	      wprof_types.h demangle.h merge.h wevent.h persist.h		\
-				pystacks.h pyoffsets.h pydisc.h pysym.h pyline.h
+				pystacks.h pyoffsets.h pydisc.h pysym.h pyline.h pytrace.h pytrace_data.h
 WPROF_OBJS := $(patsubst %.c,$(OUTPUT)/%.o,$(WPROF_SRCS))
 
-WPROFINJ_SRCS := inj_lib.c inj_strset.c inj_hashmap.c inj_cupti.c
-WPROFINJ_HDRS := inj_common.h inj.h wprof_cupti.h
+WPROFINJ_SRCS := inj_lib.c inj_strset.c inj_hashmap.c inj_cupti.c inj_pytrace.c inj_torch_profiler.c
+WPROFINJ_HDRS := inj_common.h inj.h wprof_cupti.h pytrace_data.h
 WPROFINJ_OBJS := $(patsubst %.c,$(OUTPUT)/%.o,$(WPROFINJ_SRCS))
 
 $(WPROFINJ_OBJS): ALL_CFLAGS += -fPIC

--- a/src/data.c
+++ b/src/data.c
@@ -48,6 +48,10 @@ static const char *event_kind_str_map[] = {
 	[EV_CUDA_MEMSET] = "CUDA_MEMSET",
 	[EV_CUDA_SYNC] = "CUDA_SYNC",
 	[EV_CUDA_API] = "CUDA_API",
+
+	/* Python function tracing events */
+	[EV_PYTRACE_ENTRY] = "PYTRACE_ENTRY",
+	[EV_PYTRACE_EXIT] = "PYTRACE_EXIT",
 };
 
 const char *event_kind_str(enum event_kind kind)

--- a/src/data.c
+++ b/src/data.c
@@ -52,6 +52,10 @@ static const char *event_kind_str_map[] = {
 	/* Python function tracing events */
 	[EV_PYTRACE_ENTRY] = "PYTRACE_ENTRY",
 	[EV_PYTRACE_EXIT] = "PYTRACE_EXIT",
+
+	/* PyTorch RecordFunction events */
+	[EV_PYTORCH_ENTRY] = "PYTORCH_ENTRY",
+	[EV_PYTORCH_EXIT] = "PYTORCH_EXIT",
 };
 
 const char *event_kind_str(enum event_kind kind)

--- a/src/data.h
+++ b/src/data.h
@@ -22,6 +22,7 @@ struct wprof_data_cfg {
 	u64 capture_scx : 1;
 	u64 capture_cuda : 1;
 	u64 capture_pystacks : 1;
+	u64 capture_pyfunc : 1;
 
 	enum stack_trace_kind captured_stack_traces;
 

--- a/src/data.h
+++ b/src/data.h
@@ -22,7 +22,8 @@ struct wprof_data_cfg {
 	u64 capture_scx : 1;
 	u64 capture_cuda : 1;
 	u64 capture_pystacks : 1;
-	u64 capture_pyfunc : 1;
+	u64 capture_pytrace : 1;
+	u64 capture_pytorch : 1;
 
 	enum stack_trace_kind captured_stack_traces;
 

--- a/src/emit.c
+++ b/src/emit.c
@@ -31,6 +31,12 @@ enum task_run_state {
 	TASK_STATE_PREEMPTED,
 };
 
+enum track_child_order {
+	INVALID,
+	CHRONO,
+	EXPLICIT,
+};
+
 struct task_state {
 	int tid, pid;
 	pb_iid name_iid;
@@ -86,6 +92,7 @@ enum track_special {
 
 	TKS_REQUESTS = 4,
 	TKS_CUDA = 5,
+	TKS_PYTRACE = 6,
 };
 
 #define TRACK_UUID(kind, id) (((u64)(id) * TK_MULT) + (u64)kind)
@@ -95,6 +102,7 @@ enum track_special {
 #define TRACK_UUID_KTHREAD	TRACK_UUID(TK_SPECIAL, TKS_KTHREAD)
 #define TRACK_UUID_REQUESTS	TRACK_UUID(TK_SPECIAL, TKS_REQUESTS)
 #define TRACK_UUID_CUDA		TRACK_UUID(TK_SPECIAL, TKS_CUDA)
+#define TRACK_UUID_PYTRACE	TRACK_UUID(TK_SPECIAL, TKS_PYTRACE)
 
 enum dyn_track_kind {
 	__DTK_GAP = TK_MULT - 1,	/* we need to not overlap with enum track_kind */
@@ -103,6 +111,8 @@ enum dyn_track_kind {
 	DTK_REQ,			/* single request of given PID (id1 = pid, id2 = req_id) */
 	DTK_REQ_THREAD,			/* request-participating thread (id1 = tid, id2 = req_id) */
 	DTK_REQ_THREAD_EMBED,		/* first-event-per-thread tracking for embed mode (id1 = tid, id2 = req_id) */
+	DTK_PYTRACE_PROC,	/* Python-traced process track (by PID) */
+	DTK_PYTRACE_PROC_THREAD,/* Python-traced thread track (by TID) */
 };
 
 struct track_key {
@@ -598,6 +608,16 @@ static inline u64 trackid_cuda_proc_stream(int pid, u32 stream_id)
 	return TRACK_UUID(TK_CUDA_PROC_STREAM, pid | ((u64)stream_id << 32));
 }
 
+static inline u64 trackid_pytrace_proc(int pid)
+{
+	return track_state_get_or_add(DTK_PYTRACE_PROC, pid, 0)->track_id;
+}
+
+static inline u64 trackid_pytrace_thread(int tid)
+{
+	return track_state_get_or_add(DTK_PYTRACE_PROC_THREAD, tid, 0)->track_id;
+}
+
 enum instant_scope {
 	SCOPE_THREAD,
 	SCOPE_PROCESS,
@@ -750,8 +770,20 @@ static void emit_kind_track_descr(pb_ostream_t *stream, enum task_kind k)
 	emit_trace_packet(stream, &desc_pb);
 }
 
-static void emit_track_descr(pb_ostream_t *stream, __u64 track_uuid, __u64 parent_track_uuid, const char *name, int rank)
+static void emit_track_descr_impl(pb_ostream_t *stream, __u64 track_uuid, __u64 parent_track_uuid, const char *name, int rank, enum track_child_order child_order)
 {
+	perfetto_protos_TrackDescriptor_ChildTracksOrdering child_ordering;
+	switch (child_order) {
+		case CHRONO:
+			child_ordering = perfetto_protos_TrackDescriptor_ChildTracksOrdering_CHRONOLOGICAL;
+			break;
+		case EXPLICIT:
+			child_ordering = perfetto_protos_TrackDescriptor_ChildTracksOrdering_EXPLICIT;
+			break;
+		case INVALID:
+			eprintf("BUG: invalid child_order in track_child_order()\n");
+			break;
+	}
 	TracePacket desc = {
 		PB_TRUST_SEQ_ID(PB_SEQ_ID_GENERIC),
 		PB_ONEOF(data, TracePacket_track_descriptor) = { .track_descriptor = {
@@ -760,13 +792,23 @@ static void emit_track_descr(pb_ostream_t *stream, __u64 track_uuid, __u64 paren
 			.parent_uuid = parent_track_uuid,
 			.has_parent_uuid = parent_track_uuid != 0,
 			PB_ONEOF(static_or_dynamic_name, TrackDescriptor_name) = { .name = PB_STRING(name) },
-			PB_INIT(child_ordering) = perfetto_protos_TrackDescriptor_ChildTracksOrdering_CHRONOLOGICAL,
+			PB_INIT(child_ordering) = child_ordering,
 			.sibling_order_rank = rank,
 			.has_sibling_order_rank = rank != 0,
 			PB_INIT(sibling_merge_behavior) = perfetto_protos_TrackDescriptor_SiblingMergeBehavior_SIBLING_MERGE_BEHAVIOR_NONE,
 		}},
 	};
 	emit_trace_packet(stream, &desc);
+}
+
+static void emit_track_descr(pb_ostream_t *stream, __u64 track_uuid, __u64 parent_track_uuid, const char *name, int rank)
+{
+	emit_track_descr_impl(stream, track_uuid, parent_track_uuid, name, rank, CHRONO);
+}
+
+static void emit_track_descr_explicit(pb_ostream_t *stream, __u64 track_uuid, __u64 parent_track_uuid, const char *name, int rank)
+{
+	emit_track_descr_impl(stream, track_uuid, parent_track_uuid, name, rank, EXPLICIT);
 }
 
 static void emit_process_track_descr(pb_ostream_t *stream, const struct wprof_task *t)
@@ -3226,6 +3268,18 @@ static void emit_cuda_api(struct worker_state *w, const struct wevent *e)
 	}
 
 	emit_slice_end(track_uuid, clamp_ts(e->cuda_api.end_ts), iid_str(name_iid, name), IID_CAT_CUDA_API);
+
+	if (env.capture_pytrace) {
+		struct track_state *pf = track_state_get_or_add(DTK_PYTRACE_PROC_THREAD, task.tid, 0);
+		if (pf->exists) {
+			u64 pf_track = trackid_pytrace_thread(task.tid);
+			emit_slice_begin(pf_track, clamp_ts(e->ts), iid_str(name_iid, name), IID_CAT_CUDA_API) {
+				emit_callstack(w, e->cuda_api.cuda_stack_id);
+				emit_flow_id(((u64)task.pid << 32) | e->cuda_api.corr_id);
+			}
+			emit_slice_end(pf_track, clamp_ts(e->cuda_api.end_ts), iid_str(name_iid, name), IID_CAT_CUDA_API);
+		}
+	}
 }
 
 static void emit_cuda_api_json(struct worker_state *w, const struct wevent *e)
@@ -3280,6 +3334,150 @@ static int process_cuda_api(struct worker_state *w, const struct wevent *e)
 	return 0;
 }
 
+/* PYTRACE (Python function tracing) */
+
+static u64 ensure_pytrace_proc_track(int pid, const char *proc_name)
+{
+	struct track_state *s = track_state_get_or_add(DTK_PYTRACE_PROC, pid, 0);
+	u64 track_uuid = trackid_pytrace_proc(pid);
+
+	if (!s->exists) {
+		emit_track_descr_explicit(cur_stream, track_uuid, TRACK_UUID_PYTRACE,
+					  sfmt("%s %d", proc_name, pid), 0);
+		s->exists = true;
+	}
+	return track_uuid;
+}
+
+static u64 ensure_pytrace_thread_track(int pid, int tid, const char *proc_name, const char *comm)
+{
+	ensure_pytrace_proc_track(pid, proc_name);
+
+	struct track_state *s = track_state_get_or_add(DTK_PYTRACE_PROC_THREAD, tid, 0);
+	u64 track_uuid = trackid_pytrace_thread(tid);
+
+	if (!s->exists) {
+		emit_track_descr(cur_stream, track_uuid, trackid_pytrace_proc(pid),
+				 sfmt("%s %d", comm, tid), tid);
+		s->exists = true;
+	}
+	return track_uuid;
+}
+
+static void emit_pytrace_event(struct worker_state *w, const struct wevent *e)
+{
+	struct wprof_data_hdr *hdr = w->dump_hdr;
+	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
+
+	u64 track_uuid = ensure_pytrace_thread_track(task.pid, task.tid, task.pcomm, task.comm);
+
+	const char *func_name = wevent_str(hdr, e->pytrace.func_name_stroff);
+	const char *file = e->pytrace.file_name_stroff ? wevent_str(hdr, e->pytrace.file_name_stroff) : NULL;
+	const char *base = file ? strrchr(file, '/') : NULL;
+	base = base ? base + 1 : file;
+
+	const char *display_name = base ? sfmt("%s(%u):%s", base, e->pytrace.lineno, func_name) : func_name;
+	pb_iid name_iid = emit_intern_str(w, display_name);
+
+	if (e->kind == EV_PYTRACE_ENTRY) {
+		emit_slice_begin(track_uuid, e->ts, iid_str(name_iid, display_name), IID_CAT_PYTRACE) {
+			if (file)
+				emit_kv_str(IID_ANNK_PYTRACE_FILE, file);
+			if (e->pytrace.lineno)
+				emit_kv_int(IID_ANNK_PYTRACE_LINENO, e->pytrace.lineno);
+		}
+	} else {
+		emit_slice_end(track_uuid, e->ts, iid_str(name_iid, display_name), IID_CAT_PYTRACE);
+	}
+}
+
+static void emit_pytrace_event_json(struct worker_state *w, const struct wevent *e)
+{
+	struct json_state *j = &js;
+	struct wprof_data_hdr *hdr = w->dump_hdr;
+	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
+
+	const char *func_name = wevent_str(hdr, e->pytrace.func_name_stroff);
+	const char *file = e->pytrace.file_name_stroff ? wevent_str(hdr, e->pytrace.file_name_stroff) : NULL;
+
+	json_obj_start(j);
+	json_kv_ts(j, "ts", e->ts - env.sess_start_ts);
+	json_kv_str(j, "t", e->kind == EV_PYTRACE_ENTRY ? "pytrace_entry" : "pytrace_exit");
+	json_task(j, "task", &task);
+	json_kv_str(j, "name", func_name);
+
+	if (file)
+		json_kv_str(j, "file", file);
+	if (e->pytrace.lineno)
+		json_kv_int(j, "lineno", e->pytrace.lineno);
+	json_obj_end(j);
+}
+
+static int process_pytrace(struct worker_state *w, const struct wevent *e)
+{
+	if (env.capture_pytrace != TRUE)
+		return 0;
+
+	if (!is_ts_in_range(e->ts))
+		return 0;
+
+	if (env.json_path) {
+		emit_pytrace_event_json(w, e);
+	} else {
+		emit_pytrace_event(w, e);
+	}
+	return 0;
+}
+
+static void emit_pytorch_event(struct worker_state *w, const struct wevent *e)
+{
+	struct wprof_data_hdr *hdr = w->dump_hdr;
+	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
+
+	u64 track_uuid = ensure_pytrace_thread_track(task.pid, task.tid, task.pcomm, task.comm);
+
+	const char *name = e->rf.name_stroff ? wevent_str(hdr, e->rf.name_stroff) : "?";
+	pb_iid name_iid = emit_intern_str(w, name);
+
+
+	if (e->kind == EV_PYTORCH_ENTRY) {
+		emit_slice_begin(track_uuid, e->ts, iid_str(name_iid, name), IID_CAT_PYTRACE);
+	} else {
+		emit_slice_end(track_uuid, e->ts, iid_str(name_iid, name), IID_CAT_PYTRACE);
+	}
+}
+
+static void emit_pytorch_event_json(struct worker_state *w, const struct wevent *e)
+{
+	struct json_state *j = &js;
+	struct wprof_data_hdr *hdr = w->dump_hdr;
+	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
+
+	const char *name = e->rf.name_stroff ? wevent_str(hdr, e->rf.name_stroff) : "?";
+
+	json_obj_start(j);
+	json_kv_ts(j, "ts", e->ts - env.sess_start_ts);
+	json_kv_str(j, "t", e->kind == EV_PYTORCH_ENTRY ? "pytorch_entry" : "pytorch_exit");
+	json_task(j, "task", &task);
+	json_kv_str(j, "name", name);
+	json_obj_end(j);
+}
+
+static int process_pytorch(struct worker_state *w, const struct wevent *e)
+{
+	if (env.capture_pytorch != TRUE)
+		return 0;
+
+	if (!is_ts_in_range(e->ts))
+		return 0;
+
+	if (env.json_path)
+		emit_pytorch_event_json(w, e);
+	else
+		emit_pytorch_event(w, e);
+	return 0;
+}
+
 static handle_event_fn emit_fns[] = {
 	[EV_TIMER] = process_timer,
 	[EV_SWITCH] = process_switch,
@@ -3303,6 +3501,10 @@ static handle_event_fn emit_fns[] = {
 	[EV_CUDA_MEMSET] = process_cuda_memset,
 	[EV_CUDA_SYNC] = process_cuda_sync,
 	[EV_CUDA_API] = process_cuda_api,
+	[EV_PYTRACE_ENTRY] = process_pytrace,
+	[EV_PYTRACE_EXIT] = process_pytrace,
+	[EV_PYTORCH_ENTRY] = process_pytorch,
+	[EV_PYTORCH_EXIT] = process_pytorch,
 };
 
 static void emit_header_json(struct worker_state *w)
@@ -3323,6 +3525,8 @@ static void emit_header_json(struct worker_state *w)
 	json_kv_bool(j, "capture_scx", cfg->capture_scx);
 	json_kv_bool(j, "capture_cuda", cfg->capture_cuda);
 	json_kv_bool(j, "capture_pystacks", cfg->capture_pystacks);
+	json_kv_bool(j, "capture_pytrace", cfg->capture_pytrace);
+	json_kv_bool(j, "capture_pytorch", cfg->capture_pytorch);
 
 	json_subarr_start(j, "stacks");
 	if (cfg->captured_stack_traces & ST_TIMER)
@@ -3410,6 +3614,8 @@ int emit_trace(struct worker_state *w)
 			emit_track_descr(cur_stream, TRACK_UUID_REQUESTS, 0, "REQUESTS", 1000);
 		if (env.capture_cuda)
 			emit_track_descr(cur_stream, TRACK_UUID_CUDA, 0, "CUDA", 2000);
+		if (env.capture_pytrace)
+			emit_track_descr(cur_stream, TRACK_UUID_PYTRACE, 0, "PYTRACE", 3000);
 
 		if (env.requested_stack_traces) {
 			struct wprof_stacks_hdr *shdr = wprof_stacks_hdr(w->dump_hdr);

--- a/src/env.c
+++ b/src/env.c
@@ -52,6 +52,8 @@ struct env env = {
 	.capture_cuda = UNSET,
 	.capture_pystacks = UNSET,
 	.emit_req_split = true,
+	.capture_pytrace = UNSET,
+	.capture_pytorch = UNSET,
 	.pmu_real_cnt = -1,
 	.pmu_deriv_cnt = -1,
 	.pmu_unresolved_cnt = -1,
@@ -129,7 +131,7 @@ static const struct argp_option opts[] = {
 
 	/* event subset targeting */
 	{ "feature", 'f', "FEAT", 0,
-	  "Data capture feature selector. Supported: ipi, req[=PATH|PID], scx, cuda, py-stacks[=nvidia-smi|PID].\n"
+	  "Data capture feature selector. Supported: ipi, req[=PATH|PID], scx, cuda, py-stacks[=nvidia-smi|PID], py-trace[=nvidia-smi|PID], py-torch[=nvidia-smi|PID].\n"
 	  "All features can be prefixed with 'no-' to disable them explicitly." },
 
 	/* trace emitting options */
@@ -354,6 +356,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 			env.capture_requests = val;
 		} else if (strcasecmp(arg, "scx") == 0 || strcasecmp(arg, "scx-layer") == 0) {
 			env.capture_scx = val;
+			// TODO(patlu): unified cuda/py-stacks/py-trace
 		} else if (strcasecmp(arg, "cuda") == 0) {
 			env.cuda_discovery = (val == TRUE) ? CUDA_DISCOVER_SMI : CUDA_DISCOVER_NONE;
 			env.capture_cuda = val;
@@ -406,6 +409,65 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 				return -EINVAL;
 			}
 			env.capture_pystacks = val;
+		} else if (strcasecmp(arg, "py-trace") == 0) {
+			env.pytrace_discovery = (val == TRUE) ? PYTRACE_DISCOVER_PROC : PYTRACE_DISCOVER_NONE;
+			env.capture_pytrace = val;
+			if (val == FALSE)
+				env.capture_pytorch = FALSE;
+		} else if (strcasecmp(arg, "py-trace=nvidia-smi") == 0) {
+			env.pytrace_discovery = (val == TRUE) ? PYTRACE_DISCOVER_NVIDIA_SMI : PYTRACE_DISCOVER_NONE;
+			env.capture_pytrace = val;
+			if (val == FALSE)
+				env.capture_pytorch = FALSE;
+		} else if (strncasecmp(arg, "py-trace=", 9) == 0) {
+			const char *pf_arg = arg + 9;
+			int pid, n;
+
+			if (val == FALSE) {
+				eprintf("-f no-py-trace=... feature form doesn't make much sense!\n");
+				return -EINVAL;
+			}
+
+			if (sscanf(pf_arg, "%d %n", &pid, &n) == 1 && pf_arg[n] == '\0') {
+				err = append_num(&env.pytrace_pids, &env.pytrace_pid_cnt, pf_arg);
+				if (err) {
+					eprintf("Failed to record PID '%s' for Python function tracing!\n", pf_arg);
+					return err;
+				}
+			} else {
+				eprintf("Use -fpy-trace, -fpy-trace=nvidia-smi, or -fpy-trace=<PID>!\n");
+				return -EINVAL;
+			}
+			env.capture_pytrace = val;
+		} else if (strcasecmp(arg, "py-torch") == 0) {
+			env.pytrace_discovery = (val == TRUE) ? PYTRACE_DISCOVER_PROC : PYTRACE_DISCOVER_NONE;
+			env.capture_pytrace = val;
+			env.capture_pytorch = val;
+		} else if (strcasecmp(arg, "py-torch=nvidia-smi") == 0) {
+			env.pytrace_discovery = (val == TRUE) ? PYTRACE_DISCOVER_NVIDIA_SMI : PYTRACE_DISCOVER_NONE;
+			env.capture_pytrace = val;
+			env.capture_pytorch = val;
+		} else if (strncasecmp(arg, "py-torch=", 15) == 0) {
+			const char *pf_arg = arg + 15;
+			int pid, n;
+
+			if (val == FALSE) {
+				eprintf("-f no-py-torch=... feature form doesn't make much sense!\n");
+				return -EINVAL;
+			}
+
+			if (sscanf(pf_arg, "%d %n", &pid, &n) == 1 && pf_arg[n] == '\0') {
+				err = append_num(&env.pytrace_pids, &env.pytrace_pid_cnt, pf_arg);
+				if (err) {
+					eprintf("Failed to record PID '%s' for Python function + torch tracing!\n", pf_arg);
+					return err;
+				}
+			} else {
+				eprintf("Use -fpy-torch, -fpy-torch=nvidia-smi, or -fpy-torch=<PID>!\n");
+				return -EINVAL;
+			}
+			env.capture_pytrace = val;
+			env.capture_pytorch = val;
 		} else {
 			fprintf(stderr, "Unrecognized data feature '%s!\n", arg);
 			return -EINVAL;

--- a/src/env.c
+++ b/src/env.c
@@ -95,7 +95,7 @@ static const struct argp_option opts[] = {
 	{ "verbose", 'v', NULL, 0, "Verbose output" },
 	{ "stats", OPT_STATS, NULL, 0, "Print various wprof stats (BPF, resource usage, etc.)" },
 	{ "debug", OPT_DEBUG, "FEAT", 0, "Debug features (pb-debug-interns, pb-disable-interns, keep-workdir)"},
-	{ "log", OPT_LOG, "LOG", 0, "Debug logging subset selector (libbpf, usdt, topology, inject, tracee)"},
+	{ "log", OPT_LOG, "LOG", 0, "Debug logging subset selector (libbpf, usdt, topology, inject, tracee, pytrace)"},
 	{ "dur-ms", 'd', "DURATION", 0, "Limit running duration to given number of ms (default: 1000ms)" },
 	{ "timer-freq", OPT_TIMER_FREQ, "HZ", 0, "On-CPU timer interrupt frequency (default: 100Hz, i.e., every 10ms)" },
 
@@ -223,6 +223,8 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 			env.log_set |= LOG_INJECTION;
 		} else if (strcasecmp(arg, "tracee") == 0) {
 			env.log_set |= LOG_TRACEE;
+		} else if (strcasecmp(arg, "pytrace") == 0) {
+			env.log_set |= LOG_PYTRACE;
 		} else {
 			eprintf("Unrecognized log subset '%s'!\n", arg);
 			argp_usage(state);

--- a/src/env.h
+++ b/src/env.h
@@ -8,6 +8,7 @@
 #include "wprof.h"
 #include "data.h"
 #include "cuda.h"
+#include "pytrace.h"
 #include "requests.h"
 
 #define WPROF_VERSION "0.3-dev"
@@ -23,6 +24,8 @@
 #define DEFAULT_CAPTURE_SCX FALSE
 #define DEFAULT_CAPTURE_CUDA FALSE
 #define DEFAULT_CAPTURE_PYSTACKS FALSE
+#define DEFAULT_CAPTURE_PYTRACE FALSE
+#define DEFAULT_CAPTURE_TORCH_PROFILER FALSE
 
 extern bool env_verbose;
 extern int env_debug_level;
@@ -38,6 +41,12 @@ enum pystacks_discover_strategy {
 	PYSTACKS_DISCOVER_NONE,      /* no automatic discovery */
 	PYSTACKS_DISCOVER_PROC,      /* find Python processes via /proc scan (default) */
 	PYSTACKS_DISCOVER_NVIDIA_SMI, /* use nvidia-smi to find GPU Python processes */
+};
+
+enum pytrace_discover_strategy {
+	PYTRACE_DISCOVER_NONE,		/* no automatic discovery */
+	PYTRACE_DISCOVER_PROC,		/* find Python processes via /proc scan (default) */
+	PYTRACE_DISCOVER_NVIDIA_SMI,	/* use nvidia-smi to find GPU Python processes */
 };
 
 struct req_list_cfg;
@@ -68,6 +77,8 @@ struct env {
 	enum tristate capture_scx;
 	enum tristate capture_cuda;
 	enum tristate capture_pystacks;
+	enum tristate capture_pytrace;
+	enum tristate capture_pytorch;
 
 	/* trace visualization features */
 	bool emit_sched_view;
@@ -148,6 +159,16 @@ struct env {
 	int pystacks_pid_cnt;
 	enum pystacks_discover_strategy pystacks_discovery;
 
+	/* EXPERIMENTAL (Python function tracing) */
+	int *pytrace_pids;
+	int pytrace_pid_cnt;
+	enum pytrace_discover_strategy pytrace_discovery;
+
+	struct pytrace_tracee *pytraces;
+	int pytrace_cnt;
+	bool pytraces_deactivated;
+	bool pytraces_retracted;
+
 	/* persisted data header, set after merge or before replay */
 	struct wprof_data_hdr *data_hdr;
 };
@@ -180,6 +201,12 @@ static inline void cfg_set_capture_cuda(struct wprof_data_cfg *cfg, bool val) { 
 
 static inline bool cfg_get_capture_pystacks(const struct wprof_data_cfg *cfg) { return cfg->capture_pystacks; }
 static inline void cfg_set_capture_pystacks(struct wprof_data_cfg *cfg, bool val) { cfg->capture_pystacks = val; }
+
+static inline bool cfg_get_capture_pytrace(const struct wprof_data_cfg *cfg) { return cfg->capture_pytrace; }
+static inline void cfg_set_capture_pytrace(struct wprof_data_cfg *cfg, bool val) { cfg->capture_pytrace = val; }
+
+static inline bool cfg_get_capture_pytorch(const struct wprof_data_cfg *cfg) { return cfg->capture_pytorch; }
+static inline void cfg_set_capture_pytorch(struct wprof_data_cfg *cfg, bool val) { cfg->capture_pytorch = val; }
 
 struct capture_feature {
 	const char *name;

--- a/src/inj.h
+++ b/src/inj.h
@@ -70,7 +70,10 @@ int init_cupti_activities(void);
 int start_cupti_activities(void);
 void finalize_cupti_activities(void);
 
-int pytrace_session_setup(int dump_fd, int version_minor, unsigned long *sym_addrs);
+int pytrace_session_setup(int dump_fd, int torch_fd, int version_minor, unsigned long *sym_addrs);
 int pytrace_session_finalize(void);
+
+int torch_profiler_setup(int dump_fd);
+int torch_profiler_teardown(void);
 
 #endif /* __INJ_H_ */

--- a/src/inj.h
+++ b/src/inj.h
@@ -70,4 +70,7 @@ int init_cupti_activities(void);
 int start_cupti_activities(void);
 void finalize_cupti_activities(void);
 
+int pytrace_session_setup(int dump_fd, int version_minor, unsigned long *sym_addrs);
+int pytrace_session_finalize(void);
+
 #endif /* __INJ_H_ */

--- a/src/inj_common.h
+++ b/src/inj_common.h
@@ -5,10 +5,33 @@
 
 #include "wprof_types.h"
 #include "cuda_data.h"
+#include "pytrace_data.h"
 
 #ifndef MAX_UDS_FD_CNT
 #define MAX_UDS_FD_CNT 16
 #endif
+
+#define PYTRACE_SYM_CNT 15		/* must match ARRAY_SIZE(pytrace_resolve_syms) in inj_pytrace.c */
+
+__attribute__((unused))
+static const char *pytrace_sym_names[PYTRACE_SYM_CNT] = {
+	"PyEval_SetProfile",
+	"PyGILState_Ensure",
+	"PyGILState_Release",
+	"PyFrame_GetCode",
+	"PyFrame_GetLineNumber",
+	"PyUnicode_AsUTF8",
+	"PyInterpreterState_Head",
+	"PyInterpreterState_ThreadHead",
+	"PyThreadState_Next",
+	"PyThreadState_Swap",
+	"Py_DecRef",
+	"Py_IsInitialized",
+	"PyObject_GetAttrString",
+	"PyLong_AsLong",
+	/* optional: 3.12+ only */
+	"PyEval_SetProfileAllThreads",
+};
 
 #define LIBWPROFINJ_SETUP_SYM __libwprof_inj_setup
 #define LIBWPROFINJ_VERSION 1
@@ -60,6 +83,10 @@ struct inj_run_ctx {
 	long cupti_ignore_cnt;		/* ignored records */
 	long cupti_data_sz;		/* total data size, bytes */
 	long cupti_buf_cnt;		/* buffers passed to recording callback */
+
+	/* pytrace stats */
+	long pytrace_event_cnt;		/* captured events */
+	long pytrace_code_cache_cnt;	/* unique code objects cached */
 };
 
 enum inj_msg_kind {
@@ -67,6 +94,7 @@ enum inj_msg_kind {
 	INJ_MSG_SETUP = 1,
 	INJ_MSG_CUDA_SESSION = 2,
 	INJ_MSG_SHUTDOWN = 3,
+	INJ_MSG_PYTRACE_SESSION = 4,
 };
 
 static inline const char *inj_msg_str(enum inj_msg_kind kind)
@@ -75,6 +103,7 @@ static inline const char *inj_msg_str(enum inj_msg_kind kind)
 	case INJ_MSG_SETUP: return "SETUP";
 	case INJ_MSG_CUDA_SESSION: return "CUDA_SESSION";
 	case INJ_MSG_SHUTDOWN: return "SHUTDOWN";
+	case INJ_MSG_PYTRACE_SESSION: return "PYTRACE_SESSION";
 	default: return "???";
 	}
 }
@@ -88,6 +117,11 @@ struct inj_msg {
 		struct inj_msg_cuda_session {
 			long session_timeout_ms;
 		} cuda_session;
+		struct inj_msg_pytrace_session {
+			long session_timeout_ms;
+			int py_version_minor; /* Python 3.x minor version */
+			unsigned long sym_addrs[PYTRACE_SYM_CNT];
+		} pytrace_session;
 		struct inj_msg_shutdown {
 		} shutdown;
 	};

--- a/src/inj_common.h
+++ b/src/inj_common.h
@@ -120,6 +120,7 @@ struct inj_msg {
 		struct inj_msg_pytrace_session {
 			long session_timeout_ms;
 			int py_version_minor; /* Python 3.x minor version */
+			bool enable_torch_profiler;
 			unsigned long sym_addrs[PYTRACE_SYM_CNT];
 		} pytrace_session;
 		struct inj_msg_shutdown {

--- a/src/inj_lib.c
+++ b/src/inj_lib.c
@@ -518,9 +518,9 @@ static int handle_msg(struct inj_msg *msg, int *fds, int fd_cnt)
 		vlog("Shutdown completed successfully.\n");
 		return -ESHUTDOWN;
 	case INJ_MSG_PYTRACE_SESSION: {
-		if (fd_cnt != 1) {
+		if (fd_cnt < 1 || fd_cnt > 2) {
 			err = -EPROTO;
-			elog("Received PYTRACE_SESSION command, but no dump FD!\n");
+			elog("Received PYTRACE_SESSION command with unexpected FD count %d!\n", fd_cnt);
 			return err;
 		}
 
@@ -529,7 +529,8 @@ static int handle_msg(struct inj_msg *msg, int *fds, int fd_cnt)
 		vlog("Setting up pytrace session (timeout %ldms, Python 3.%d)...\n", sess_timeout_ms, py_ver_minor);
 
 		int dump_fd = fds[0];
-		if ((err = pytrace_session_setup(dump_fd, py_ver_minor, msg->pytrace_session.sym_addrs)) < 0) {
+		int torch_fd = (fd_cnt >= 2 && msg->pytrace_session.enable_torch_profiler) ? fds[1] : -1;
+		if ((err = pytrace_session_setup(dump_fd, torch_fd, py_ver_minor, msg->pytrace_session.sym_addrs)) < 0) {
 			elog("Failed to setup pytrace session: %d\n", err);
 			return err;
 		}

--- a/src/inj_lib.c
+++ b/src/inj_lib.c
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <dlfcn.h>
@@ -27,6 +28,7 @@
 #include "inj_common.h"
 #include "strset.h"
 #include "cuda_data.h"
+#include "pytrace_data.h"
 
 #define WPROFINJ_THREAD_NAME "wprofinj"
 #define WPROFINJ_CUPTI_THREAD_NAME "wprofinj-cupti"
@@ -174,14 +176,16 @@ static void *stack = NULL;
 static int exit_fd = -1;
 static pid_t worker_tid; /* for clone() and futex() only */
 static int epoll_fd = -1;
-static int timer_fd = -1;
+static int cuda_timer_fd = -1;
+static int pytrace_timer_fd = -1;
 
 static char msg_buf[UDS_MAX_MSG_LEN] __attribute__((aligned(8)));
 
 enum epoll_kind {
 	EK_EXIT,
 	EK_UDS,
-	EK_TIMER,
+	EK_TIMER_CUDA,
+	EK_TIMER_PYTRACE,
 };
 
 static int epoll_add(int epoll_fd, int fd, __u32 epoll_events, enum epoll_kind kind)
@@ -210,6 +214,8 @@ static int epoll_del(int epoll_fd, int fd)
 	}
 	return 0;
 }
+
+static bool pytrace_session_active;
 
 #define CUDA_DUMP_BUF_SZ (256 * 1024)
 static FILE *cuda_dump;
@@ -368,15 +374,55 @@ static int handle_session_end(void)
 	finalize_cupti_activities();
 
 	/* exit and timer events are racing each other, we finalize just once */
-	if (!cuda_dump)
-		return 0;
+	if (cuda_dump) {
+		err = cuda_dump_finalize();
+		if (err) {
+			elog("Failed to finalize CUDA data dump: %d\n", err);
+			return err;
+		}
+	}
 
-	err = cuda_dump_finalize();
-	if (err) {
-		elog("Failed to finalize CUDA data dump: %d\n", err);
+	if (pytrace_session_active) {
+		err = pytrace_session_finalize();
+		if (err) {
+			elog("Failed to finalize pytrace data dump: %d\n", err);
+			return err;
+		}
+	}
+
+	return 0;
+}
+
+static int setup_session_timer(int *timer_fd_out, long timeout_ms, enum epoll_kind kind)
+{
+	int err;
+	int fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
+	if (fd < 0) {
+		err = -errno;
+		elog("Failed to create timerfd: %d\n", err);
 		return err;
 	}
 
+	struct itimerspec spec = {
+		.it_value = {
+			.tv_sec = timeout_ms / 1000,
+			.tv_nsec = timeout_ms % 1000 * 1000000,
+		},
+	};
+	if (timerfd_settime(fd, 0, &spec, NULL) < 0) {
+		err = -errno;
+		elog("Failed to timerfd_settime(): %d\n", err);
+		zclose(fd);
+		return err;
+	}
+
+	if ((err = epoll_add(epoll_fd, fd, EPOLLIN, kind)) < 0) {
+		elog("Failed to add timerfd into epoll: %d\n", err);
+		zclose(fd);
+		return err;
+	}
+
+	*timer_fd_out = fd;
 	return 0;
 }
 
@@ -408,10 +454,6 @@ static int handle_msg(struct inj_msg *msg, int *fds, int fd_cnt)
 		vlog("Log setup completed successfully! wprof PID is %d. wprofinj TID %d PID %d REAL PID %d\n",
 		     setup_ctx->parent_pid, gettid(), getpid(), setup_ctx->tracee_pid);
 
-		err = init_cupti_activities();
-		if (err)
-			return err;
-
 		zclose(run_ctx_memfd);
 		break;
 	}
@@ -424,6 +466,12 @@ static int handle_msg(struct inj_msg *msg, int *fds, int fd_cnt)
 
 		long sess_timeout_ms = msg->cuda_session.session_timeout_ms;
 		vlog("Setting up CUDA session (timeout %ldms)...\n", sess_timeout_ms);
+
+		err = init_cupti_activities();
+		if (err) {
+			elog("Failed to initialize CUPTI: %d\n", err);
+			return err;
+		}
 
 		int dump_fd = fds[0];
 		if ((err = cuda_dump_setup(dump_fd)) < 0) {
@@ -450,27 +498,8 @@ static int handle_msg(struct inj_msg *msg, int *fds, int fd_cnt)
 
 		run_ctx->setup_state = INJ_SETUP_READY;
 
-		timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
-		if (timer_fd < 0) {
-			err = -errno;
-			elog("Failed to create timerfd: %d\n", err);
-			return err;
-		}
-
-		struct itimerspec spec = {
-			.it_value = {
-				.tv_sec = sess_timeout_ms / 1000,
-				.tv_nsec = sess_timeout_ms % 1000 * 1000000,
-			},
-		};
-		if (timerfd_settime(timer_fd, 0, &spec, NULL) < 0) {
-			err = -errno;
-			elog("Failed to timerfd_settime(): %d\n", err);
-			return err;
-		}
-
-		if ((err = epoll_add(epoll_fd, timer_fd, EPOLLIN, EK_TIMER)) < 0) {
-			elog("Failed to add timerfd into epoll: %d\n", err);
+		if ((err = setup_session_timer(&cuda_timer_fd, sess_timeout_ms, EK_TIMER_CUDA)) < 0) {
+			elog("Failed to set up CUDA session timer: %d\n", err);
 			return err;
 		}
 
@@ -482,12 +511,40 @@ static int handle_msg(struct inj_msg *msg, int *fds, int fd_cnt)
 
 		err = handle_session_end();
 		if (err) {
-			elog("Failed to cleanly handle CUDA session end: %d\n", err);
+			elog("Failed to cleanly handle session end: %d\n", err);
 			return err;
 		}
 
 		vlog("Shutdown completed successfully.\n");
 		return -ESHUTDOWN;
+	case INJ_MSG_PYTRACE_SESSION: {
+		if (fd_cnt != 1) {
+			err = -EPROTO;
+			elog("Received PYTRACE_SESSION command, but no dump FD!\n");
+			return err;
+		}
+
+		long sess_timeout_ms = msg->pytrace_session.session_timeout_ms;
+		int py_ver_minor = msg->pytrace_session.py_version_minor;
+		vlog("Setting up pytrace session (timeout %ldms, Python 3.%d)...\n", sess_timeout_ms, py_ver_minor);
+
+		int dump_fd = fds[0];
+		if ((err = pytrace_session_setup(dump_fd, py_ver_minor, msg->pytrace_session.sym_addrs)) < 0) {
+			elog("Failed to setup pytrace session: %d\n", err);
+			return err;
+		}
+
+		pytrace_session_active = true;
+		run_ctx->setup_state = INJ_SETUP_READY;
+
+		if ((err = setup_session_timer(&pytrace_timer_fd, sess_timeout_ms, EK_TIMER_PYTRACE)) < 0) {
+			elog("Failed to set up pytrace session timer: %d\n", err);
+			return err;
+		}
+
+		vlog("pytrace session setup complete.\n");
+		break;
+	}
 	default:
 		elog("Unexpected message (kind %d)!\n", msg->kind);
 		return -EINVAL;
@@ -604,18 +661,22 @@ event_loop:
 				goto cleanup;
 			}
 			break;
-		case EK_TIMER: {
+		case EK_TIMER_CUDA:
+		case EK_TIMER_PYTRACE: {
 			long long expirations;
-			(void)read(timer_fd, &expirations, sizeof(expirations));
+			enum epoll_kind kind = evs[i].data.u32;
+			int fd = kind == EK_TIMER_CUDA ? cuda_timer_fd : pytrace_timer_fd;
+			const char *kind_str = kind == EK_TIMER_CUDA ? "CUDA" : "PYTRACE";
+			(void)read(fd, &expirations, sizeof(expirations));
 
 			err = handle_session_end();
 			if (err) {
-				elog("Failed to cleanly handle CUDA session end: %d\n", err);
+				elog("Failed to cleanly handle %s session end: %d\n", kind_str, err);
 				goto cleanup;
 			}
 
-			vlog("CUDA session timer expired with %.3lfms delay after planned session end.\n",
-			     (ktime_now_ns() - run_ctx->sess_end_ts) / 1000000.0);
+			vlog("%s session timer expired with %.3lfms delay after planned session end.\n",
+			     kind_str, (ktime_now_ns() - run_ctx->sess_end_ts) / 1000000.0);
 			break;
 		}
 		case EK_EXIT:
@@ -646,7 +707,8 @@ cleanup:
 	zclose(setup_ctx->uds_fd);
 	zclose(run_ctx_memfd);
 	zclose(epoll_fd);
-	zclose(timer_fd);
+	zclose(cuda_timer_fd);
+	zclose(pytrace_timer_fd);
 
 	if (err) {
 		if (run_ctx && run_ctx->setup_state == INJ_SETUP_PENDING) {

--- a/src/inj_pytrace.c
+++ b/src/inj_pytrace.c
@@ -304,7 +304,7 @@ static int init_wpytrace_data(FILE *dump)
 	return 0;
 }
 
-int pytrace_session_setup(int dump_fd, int version_minor, unsigned long *sym_addrs)
+int pytrace_session_setup(int dump_fd, int torch_fd, int version_minor, unsigned long *sym_addrs)
 {
 	int err = 0;
 
@@ -395,6 +395,14 @@ int pytrace_session_setup(int dump_fd, int version_minor, unsigned long *sym_add
 
 	vlog("pytrace session ready: profiler active on %d Python thread(s)\n", thread_cnt);
 
+	/* Set up torch profiler if requested */
+	if (torch_fd >= 0) {
+		err = torch_profiler_setup(torch_fd);
+		if (err) {
+			vlog("Torch profiler setup failed: %d\n", err);
+			goto cleanup;
+		}
+	}
 
 	return 0;
 
@@ -421,6 +429,9 @@ int pytrace_session_finalize(void)
 
 	if (!pytrace_dump)
 		return 0;
+
+	/* Uninstall torch profiler first (doesn't need GIL) */
+	torch_profiler_teardown();
 
 	/* Uninstall profiler */
 	pytrace_active = false;

--- a/src/inj_pytrace.c
+++ b/src/inj_pytrace.c
@@ -1,0 +1,555 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2026 Meta Platforms, Inc. */
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+
+#include "inj.h"
+#include "inj_common.h"
+#include "pytrace_data.h"
+#include "strset.h"
+#include "hashmap.h"
+
+/* Python C API type stubs -- opaque pointers, we only need them for signatures */
+typedef void PyObject;
+typedef void PyFrameObject;
+typedef void PyCodeObject;
+typedef void PyThreadState;
+typedef void PyInterpreterState;
+
+/* GIL state */
+typedef int PyGILState_STATE;
+
+/* Py_tracefunc signature: int callback(PyObject *obj, PyFrameObject *frame, int what, PyObject *arg) */
+typedef int (*Py_tracefunc)(PyObject *, PyFrameObject *, int, PyObject *);
+
+/* PyTrace_* constants (from cpython/pystate.h) */
+#define PYTRACE_CALL    0
+#define PYTRACE_RETURN  3
+
+/* Python C API function pointers */
+static void (*py_eval_set_profile)(Py_tracefunc, PyObject *);
+static PyGILState_STATE (*py_gilstate_ensure)(void);
+static void (*py_gilstate_release)(PyGILState_STATE);
+static PyCodeObject *(*py_frame_getcode)(PyFrameObject *);
+static int (*py_frame_getlineno)(PyFrameObject *);
+static const char *(*py_unicode_asutf8)(PyObject *);
+static PyInterpreterState *(*py_interp_head)(void);
+static PyThreadState *(*py_interp_threadhead)(PyInterpreterState *);
+static PyThreadState *(*py_threadstate_next)(PyThreadState *);
+static PyThreadState *(*py_threadstate_swap)(PyThreadState *);
+static void (*py_decref)(PyObject *);
+static int (*py_is_initialized)(void);
+static PyObject *(*py_getattr_string)(PyObject *, const char *);
+static long (*py_long_aslong)(PyObject *);
+/* Optional: 3.12+ bulk profiler install */
+static void (*py_eval_set_profile_all_threads)(Py_tracefunc, PyObject *);
+
+static void *pytrace_resolve_syms[PYTRACE_SYM_CNT] = {
+	&py_eval_set_profile,
+	&py_gilstate_ensure,
+	&py_gilstate_release,
+	&py_frame_getcode,
+	&py_frame_getlineno,
+	&py_unicode_asutf8,
+	&py_interp_head,
+	&py_interp_threadhead,
+	&py_threadstate_next,
+	&py_threadstate_swap,
+	&py_decref,
+	&py_is_initialized,
+	&py_getattr_string,
+	&py_long_aslong,
+	&py_eval_set_profile_all_threads,
+};
+
+/* Session state */
+static int py_version_minor;
+static bool pytrace_active;
+
+/* Dump file state */
+#define PYTRACE_DUMP_BUF_SZ (256 * 1024)
+static FILE *pytrace_dump;
+static u64 pytrace_event_cnt;
+
+#ifdef DEBUG
+#define MAX_TRACED_THREADS 64
+#define PYTRACE_TYPE_CNT 7  /* CALL=0, EXCEPTION=1, LINE=2, RETURN=3, C_CALL=4, C_EXCEPTION=5, C_RETURN=6 */
+static struct {
+	u32 tid;
+	u64 counts[PYTRACE_TYPE_CNT];
+} pytrace_thread_stats[MAX_TRACED_THREADS];
+static int pytrace_thread_stats_cnt;
+#endif
+
+#define PYTRACE_DUMP_MAX_STRS_SZ (256 * 1024 * 1024)
+struct strset *pytrace_dump_strs;
+
+/* Code object cache: PyCodeObject* -> cached info */
+struct pytrace_code_info {
+	u32 func_name_off;	/* offset into pytrace_dump_strs */
+	u32 file_name_off;	/* offset into pytrace_dump_strs */
+	u32 lineno;
+};
+
+static struct hashmap *pytrace_code_cache;
+static struct pytrace_code_info *pytrace_code_entries;
+static u64 *pytrace_code_keys;
+static u32 pytrace_code_cnt;
+static u32 pytrace_code_cap;
+
+static size_t pytrace_code_hash_fn(long key, void *ctx)
+{
+	/* Hash pointer value directly */
+	u64 k = (u64)key;
+	return k ^ (k >> 16) ^ (k >> 32);
+}
+
+static bool pytrace_code_equal_fn(long a, long b, void *ctx)
+{
+	return a == b;
+}
+
+/*
+ * Extract function info from a PyCodeObject, with version-specific handling.
+ * Returns the code_info index (into pytrace_code_entries).
+ */
+static u32 pytrace_cache_code(u64 code_key, PyCodeObject *code)
+{
+	long idx;
+
+	if (hashmap__find(pytrace_code_cache, (long)code_key, &idx))
+		return (u32)idx;
+
+	/* First encounter: extract strings from the code object */
+	const char *func_name = NULL;
+	const char *file_name = NULL;
+	int lineno = 0;
+
+	/*
+	 * co_qualname is available in 3.11+. In 3.10, fall back to co_name.
+	 * Both are PyUnicodeObject fields on the code object.
+	 *
+	 * For name extraction, we peek at the code object's fields directly.
+	 * PyCodeObject layout has co_name and co_filename as PyObject* members.
+	 * We resolve them based on Python version.
+	 */
+
+	/*
+	 * Use the frame's code object fields. In CPython, PyCodeObject has:
+	 * - co_filename (all versions)
+	 * - co_name (all versions)
+	 * - co_qualname (3.11+)
+	 * - co_firstlineno (all versions)
+	 *
+	 * We access these by resolving co_qualname/co_name/co_filename as
+	 * PyObject* attributes. Since we have the code object, we use
+	 * public accessors where available, otherwise struct field access.
+	 */
+
+	PyObject *name_obj = NULL;
+	PyObject *file_obj = NULL;
+
+	/* Try co_qualname first (3.11+), fall back to co_name */
+	if (py_version_minor >= 11) {
+		name_obj = py_getattr_string(code, "co_qualname");
+		if (name_obj) {
+			func_name = py_unicode_asutf8(name_obj);
+			py_decref(name_obj);
+		}
+	}
+	if (!func_name) {
+		name_obj = py_getattr_string(code, "co_name");
+		if (name_obj) {
+			func_name = py_unicode_asutf8(name_obj);
+			py_decref(name_obj);
+		}
+	}
+
+	file_obj = py_getattr_string(code, "co_filename");
+	if (file_obj) {
+		file_name = py_unicode_asutf8(file_obj);
+		py_decref(file_obj);
+	}
+
+	PyObject *lineno_obj = py_getattr_string(code, "co_firstlineno");
+	if (lineno_obj) {
+		lineno = (int)py_long_aslong(lineno_obj);
+		py_decref(lineno_obj);
+	}
+
+	if (!func_name)
+		func_name = "<unknown>";
+	if (!file_name)
+		file_name = "<unknown>";
+
+	/* Grow entries array if needed */
+	if (pytrace_code_cnt >= pytrace_code_cap) {
+		u32 new_cap = pytrace_code_cap ? pytrace_code_cap * 3 / 2 : 1024;
+		pytrace_code_entries = realloc(pytrace_code_entries, new_cap * sizeof(*pytrace_code_entries));
+		pytrace_code_keys = realloc(pytrace_code_keys, new_cap * sizeof(*pytrace_code_keys));
+		pytrace_code_cap = new_cap;
+	}
+
+	idx = pytrace_code_cnt;
+	pytrace_code_keys[idx] = code_key;
+	pytrace_code_entries[idx].func_name_off = strset__add_str(pytrace_dump_strs, func_name);
+	pytrace_code_entries[idx].file_name_off = strset__add_str(pytrace_dump_strs, file_name);
+	pytrace_code_entries[idx].lineno = lineno;
+	pytrace_code_cnt++;
+
+	hashmap__add(pytrace_code_cache, (long)code_key, idx);
+
+	return (u32)idx;
+}
+
+/*
+ * The profiling callback installed via PyEval_SetProfile.
+ * Called on every function call/return. Must be extremely fast.
+ */
+static int pytrace_profile_callback(PyObject *obj, PyFrameObject *frame, int what, PyObject *arg)
+{
+	if (!pytrace_active)
+		return 0;
+
+	/* Minimize skew with other collectors (e.g. cuda) */
+	if (!run_ctx->sess_start_ts)
+		return 0;
+
+	u64 ts = ktime_now_ns();
+	u32 tid = (u32)syscall(SYS_gettid);
+
+#ifdef DEBUG
+	/* Count events by (tid, type) for debugging */
+	int si;
+	for (si = 0; si < pytrace_thread_stats_cnt; si++) {
+		if (pytrace_thread_stats[si].tid == tid)
+			break;
+	}
+	if (si == pytrace_thread_stats_cnt && si < MAX_TRACED_THREADS) {
+		pytrace_thread_stats[si].tid = tid;
+		pytrace_thread_stats_cnt++;
+	}
+	if (si < MAX_TRACED_THREADS && what < PYTRACE_TYPE_CNT)
+		pytrace_thread_stats[si].counts[what]++;
+#endif
+
+	bool is_tracked = (what == PYTRACE_CALL || what == PYTRACE_RETURN);
+	if (!is_tracked)
+		return 0;
+
+	/* Get the code object for this frame */
+	PyCodeObject *code = py_frame_getcode(frame);
+	u64 code_key = (u64)code;
+
+	/* Cache the code object info (extracts strings only on first encounter) */
+	pytrace_cache_code(code_key, code);
+
+	/* In 3.11+, PyFrame_GetCode returns a new reference */
+	if (py_version_minor >= 11)
+		py_decref(code);
+
+	/* Record the raw event */
+	struct wpytrace_event ev = {
+		.ts = ts,
+		.tid = tid,
+		.what = (u8)what,
+		.code_key = code_key,
+	};
+
+	if (fwrite(&ev, sizeof(ev), 1, pytrace_dump) != 1) {
+		elog("Failed to write pytrace event: %d\n", -errno);
+		return 0;
+	}
+
+	pytrace_event_cnt++;
+	return 0;
+}
+
+static void init_wpytrace_header(struct wpytrace_data_hdr *hdr)
+{
+	memset(hdr, 0, sizeof(*hdr));
+	memcpy(hdr->magic, "WPYFUNC", 8);
+	hdr->hdr_sz = sizeof(*hdr);
+}
+
+static int init_wpytrace_data(FILE *dump)
+{
+	int err;
+
+	err = fseek(dump, 0, SEEK_SET);
+	if (err) {
+		err = -errno;
+		elog("Failed to fseek(0) pytrace data dump: %d\n", err);
+		return err;
+	}
+
+	struct wpytrace_data_hdr hdr;
+	init_wpytrace_header(&hdr);
+	hdr.flags = WPYTRACE_DATA_FLAG_INCOMPLETE;
+
+	if (fwrite(&hdr, sizeof(hdr), 1, dump) != 1) {
+		err = -errno;
+		elog("Failed to fwrite() pytrace data dump header: %d\n", err);
+		return err;
+	}
+
+	fflush(dump);
+	fsync(fileno(dump));
+	return 0;
+}
+
+int pytrace_session_setup(int dump_fd, int version_minor, unsigned long *sym_addrs)
+{
+	int err = 0;
+
+	py_version_minor = version_minor;
+	vlog("Setting up pytrace session (Python 3.%d)...\n", py_version_minor);
+
+	/* Assign Python C API function pointers from host-resolved addresses */
+	for (int i = 0; i < PYTRACE_SYM_CNT; i++) {
+		*(void **)pytrace_resolve_syms[i] = (void *)sym_addrs[i];
+		if (sym_addrs[i])
+			vlog("  %s = %p\n", pytrace_sym_names[i], (void *)sym_addrs[i]);
+	}
+
+	/* Set up dump file */
+	pytrace_dump_strs = strset__new(PYTRACE_DUMP_MAX_STRS_SZ, "", 1);
+	if (!pytrace_dump_strs) {
+		elog("Failed to create pytrace string set\n");
+		return -ENOMEM;
+	}
+
+	pytrace_dump = fdopen(dump_fd, "w");
+	if (!pytrace_dump) {
+		err = -errno;
+		elog("Failed to create FILE wrapper around pytrace dump FD %d: %d\n", dump_fd, err);
+		goto cleanup;
+	}
+	setvbuf(pytrace_dump, NULL, _IOFBF, PYTRACE_DUMP_BUF_SZ);
+
+	if ((err = init_wpytrace_data(pytrace_dump)) < 0) {
+		elog("Failed to init pytrace dump: %d\n", err);
+		goto cleanup;
+	}
+
+	/* Initialize code object cache */
+	pytrace_code_cache = hashmap__new(pytrace_code_hash_fn, pytrace_code_equal_fn, NULL);
+	if (!pytrace_code_cache) {
+		err = -ENOMEM;
+		elog("Failed to create pytrace code cache\n");
+		goto cleanup;
+	}
+
+	/* Install profiler on all Python threads */
+	if (!py_is_initialized()) {
+		elog("Python interpreter not initialized, skipping pytrace\n");
+		err = -ENOENT;
+		goto cleanup;
+	}
+
+	pytrace_active = true;
+
+	PyGILState_STATE gstate = py_gilstate_ensure();
+
+	PyInterpreterState *interp = py_interp_head();
+	if (!interp) {
+		elog("No Python interpreter found!\n");
+		py_gilstate_release(gstate);
+		err = -ENOENT;
+		goto cleanup;
+	}
+
+	int thread_cnt = 0;
+
+	if (py_eval_set_profile_all_threads) {
+		/* 3.12+: install on all threads in one call */
+		py_eval_set_profile_all_threads(pytrace_profile_callback, NULL);
+		for (PyThreadState *ts = py_interp_threadhead(interp); ts; ts = py_threadstate_next(ts))
+			thread_cnt++;
+		vlog("pytrace profiler installed on all threads via PyEval_SetProfileAllThreads\n");
+	} else {
+		/*
+		 * Pre-3.12: swap to each thread state and install individually.
+		 * PyEval_SetProfile installs on the "current" thread state, so we
+		 * must swap to each real Python thread's state to install on it.
+		 */
+		PyThreadState *saved = py_threadstate_swap(NULL);
+
+		for (PyThreadState *ts = py_interp_threadhead(interp); ts; ts = py_threadstate_next(ts)) {
+			py_threadstate_swap(ts);
+			py_eval_set_profile(pytrace_profile_callback, NULL);
+			thread_cnt++;
+		}
+
+		py_threadstate_swap(saved);
+		vlog("pytrace profiler installed on %d threads via PyThreadState_Swap\n", thread_cnt);
+	}
+
+	py_gilstate_release(gstate);
+
+	vlog("pytrace session ready: profiler active on %d Python thread(s)\n", thread_cnt);
+
+
+	return 0;
+
+cleanup:
+	pytrace_active = false;
+	if (pytrace_code_cache) {
+		hashmap__free(pytrace_code_cache);
+		pytrace_code_cache = NULL;
+	}
+	strset__free(pytrace_dump_strs);
+	pytrace_dump_strs = NULL;
+	if (pytrace_dump) {
+		fclose(pytrace_dump);
+		pytrace_dump = NULL;
+	} else {
+		zclose(dump_fd);
+	}
+	return err;
+}
+
+int pytrace_session_finalize(void)
+{
+	int err = 0;
+
+	if (!pytrace_dump)
+		return 0;
+
+	/* Uninstall profiler */
+	pytrace_active = false;
+
+	PyGILState_STATE gstate = py_gilstate_ensure();
+
+	if (py_eval_set_profile_all_threads) {
+		py_eval_set_profile_all_threads(NULL, NULL);
+	} else {
+		PyInterpreterState *interp = py_interp_head();
+		if (interp) {
+			PyThreadState *saved = py_threadstate_swap(NULL);
+			for (PyThreadState *ts = py_interp_threadhead(interp); ts; ts = py_threadstate_next(ts)) {
+				py_threadstate_swap(ts);
+				py_eval_set_profile(NULL, NULL);
+			}
+			py_threadstate_swap(saved);
+		}
+	}
+
+	py_gilstate_release(gstate);
+
+	fflush(pytrace_dump);
+
+	long events_end = ftell(pytrace_dump);
+	if (events_end < 0) {
+		err = -errno;
+		elog("Failed to get pytrace dump file position: %d\n", err);
+		return err;
+	}
+
+	/* Write code object map */
+	long code_map_off = events_end - sizeof(struct wpytrace_data_hdr);
+	for (u32 i = 0; i < pytrace_code_cnt; i++) {
+		struct wpytrace_code_entry entry = {
+			.code_key = pytrace_code_keys[i],
+			.func_name_off = pytrace_code_entries[i].func_name_off,
+			.file_name_off = pytrace_code_entries[i].file_name_off,
+			.lineno = pytrace_code_entries[i].lineno,
+		};
+		if (fwrite(&entry, sizeof(entry), 1, pytrace_dump) != 1) {
+			err = -errno;
+			elog("Failed to write pytrace code map entry: %d\n", err);
+			return err;
+		}
+	}
+	long code_map_sz = pytrace_code_cnt * sizeof(struct wpytrace_code_entry);
+
+	/* Write string table */
+	const char *strs = strset__data(pytrace_dump_strs);
+	size_t strs_sz = strset__data_size(pytrace_dump_strs);
+
+	long strs_off = ftell(pytrace_dump) - sizeof(struct wpytrace_data_hdr);
+	if (strs_sz > 0 && fwrite(strs, 1, strs_sz, pytrace_dump) != strs_sz) {
+		err = -errno;
+		elog("Failed to write pytrace strings: %d\n", err);
+		return err;
+	}
+
+	fsync(fileno(pytrace_dump));
+
+	/* Finalize header */
+	struct wpytrace_data_hdr hdr;
+	init_wpytrace_header(&hdr);
+
+	hdr.sess_start_ns = run_ctx->sess_start_ts;
+	hdr.sess_end_ns = run_ctx->sess_end_ts;
+	hdr.events_off = 0;
+	hdr.events_sz = events_end - sizeof(struct wpytrace_data_hdr);
+	hdr.event_cnt = pytrace_event_cnt;
+	hdr.code_map_off = code_map_off;
+	hdr.code_map_sz = code_map_sz;
+	hdr.code_map_cnt = pytrace_code_cnt;
+	hdr.strs_off = strs_off;
+	hdr.strs_sz = strs_sz;
+
+	err = fseek(pytrace_dump, 0, SEEK_SET);
+	if (err) {
+		err = -errno;
+		elog("Failed to fseek(0) pytrace dump: %d\n", err);
+		return err;
+	}
+
+	if (fwrite(&hdr, sizeof(hdr), 1, pytrace_dump) != 1) {
+		err = -errno;
+		elog("Failed to fwrite() pytrace dump header: %d\n", err);
+		return err;
+	}
+
+	fflush(pytrace_dump);
+	fsync(fileno(pytrace_dump));
+
+	/* Update run_ctx stats */
+	if (run_ctx) {
+		run_ctx->pytrace_event_cnt = pytrace_event_cnt;
+		run_ctx->pytrace_code_cache_cnt = pytrace_code_cnt;
+	}
+
+#ifdef DEBUG
+	static const char *pytrace_names[] = {"CALL", "EXCEPTION", "LINE", "RETURN", "C_CALL", "C_EXCEPTION", "C_RETURN"};
+	for (int i = 0; i < pytrace_thread_stats_cnt; i++) {
+		char buf[256];
+		int off = snprintf(buf, sizeof(buf), "pytrace tid %u:", pytrace_thread_stats[i].tid);
+		for (int j = 0; j < PYTRACE_TYPE_CNT; j++) {
+			if (pytrace_thread_stats[i].counts[j])
+				off += snprintf(buf + off, sizeof(buf) - off, " %s=%llu",
+						pytrace_names[j], (unsigned long long)pytrace_thread_stats[i].counts[j]);
+		}
+		vlog("%s\n", buf);
+	}
+#endif
+
+	vlog("pytrace session finalized: %llu events, %u code objects, %zu string bytes\n",
+	     pytrace_event_cnt, pytrace_code_cnt, strs_sz);
+
+	fclose(pytrace_dump);
+	pytrace_dump = NULL;
+
+	/* Cleanup */
+	hashmap__free(pytrace_code_cache);
+	pytrace_code_cache = NULL;
+	free(pytrace_code_entries);
+	pytrace_code_entries = NULL;
+	free(pytrace_code_keys);
+	pytrace_code_keys = NULL;
+	pytrace_code_cnt = 0;
+	pytrace_code_cap = 0;
+	strset__free(pytrace_dump_strs);
+	pytrace_dump_strs = NULL;
+
+	return 0;
+}

--- a/src/inj_torch_profiler.c
+++ b/src/inj_torch_profiler.c
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2026 Meta Platforms, Inc. */
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <dlfcn.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "inj.h"
+#include "pytrace_data.h"
+#include "strset.h"
+
+/* ==================== RecordFunction hooking ====================
+ *
+ * PyTorch's RecordFunction callback system lets us capture ops on autograd
+ * threads (pt_autograd_0, etc.) which never execute Python code and thus
+ * can't be reached via PyEval_SetProfile.
+ *
+ * We resolve the C++ API symbols from libtorch_cpu.so via their mangled names
+ * and construct the RecordFunctionCallback struct manually to match the ABI.
+ */
+
+/* Dump file state (own, not shared with inj_pytrace.c) */
+#define TORCH_DUMP_BUF_SZ (256 * 1024)
+#define TORCH_DUMP_MAX_STRS_SZ (256 * 1024 * 1024)
+
+static FILE *torch_dump;
+static struct strset *torch_dump_strs;
+static u64 torch_event_cnt;
+
+static bool torch_active;
+
+/* RecordFunction C++ API — resolved via dlsym with mangled names */
+static const char *(*rf_name)(const void *record_fn);
+static void (*rf_remove_callback)(u64 handle);
+
+/*
+ * addGlobalCallback takes a 40-byte RecordFunctionCallback struct by value.
+ * On x86_64, structs >16 bytes are passed on the stack. On aarch64, they're
+ * passed by indirect reference (pointer in x0). In both cases the C compiler
+ * generates the correct calling convention automatically when we call through
+ * a function pointer typed to take the struct by value.
+ */
+static void *rf_add_global_callback_ptr;
+
+static u64 rf_callback_handle;
+static bool rf_active;
+
+/*
+ * RecordFunction start callback (C ABI matching C++ hidden-return-pointer convention).
+ *
+ * C++ signature: std::unique_ptr<ObserverContext> (*)(const RecordFunction&)
+ * The hidden return pointer for non-trivial return types is passed differently:
+ *   x86_64:  rdi (1st param reg) = ret_slot, rsi (2nd) = record_fn
+ *   aarch64: x8 (dedicated reg) = ret_slot, x0 (1st param reg) = record_fn
+ *
+ * On x86_64 we can map ret_slot to the first C parameter directly.
+ * On aarch64 we need a naked thunk to shuffle x8→x0 and x0→x1.
+ */
+#if defined(__aarch64__)
+/*
+ * aarch64 thunk: the C++ caller passes x8=ret_slot, x0=record_fn.
+ * Shuffle to match rf_start_cb_impl(x0=ret_slot, x1=record_fn).
+ * Top-level asm avoids GCC ignoring __attribute__((naked)) in some versions.
+ */
+__attribute__((visibility("hidden")))
+void *rf_start_cb_impl(void *ret_slot, const void *record_fn);
+
+__asm__(
+	".type rf_start_cb, %function\n"
+	"rf_start_cb:\n"
+	"mov x1, x0\n"
+	"mov x0, x8\n"
+	"b rf_start_cb_impl\n"
+	".size rf_start_cb, .-rf_start_cb\n"
+);
+
+/* Declare the asm-defined symbol so C code can reference it */
+extern void *rf_start_cb();
+
+__attribute__((visibility("hidden")))
+void *rf_start_cb_impl(void *ret_slot, const void *record_fn)
+#else
+static void *rf_start_cb(void *ret_slot, const void *record_fn)
+#endif
+{
+	if (!torch_active || !torch_dump) {
+		*(void **)ret_slot = NULL;
+		return ret_slot;
+	}
+	if (!run_ctx->sess_start_ts) {
+		*(void **)ret_slot = NULL;
+		return ret_slot;
+	}
+
+	u64 ts = ktime_now_ns();
+	u32 tid = (u32)syscall(SYS_gettid);
+	const char *name = rf_name ? rf_name(record_fn) : "?";
+
+	u32 name_off = strset__add_str(torch_dump_strs, name);
+
+	struct wpytrace_event ev = {
+		.ts = ts,
+		.tid = tid,
+		.what = WPYTRACE_PYTORCH_ENTRY,
+		.code_key = 0,
+		.rf_name_off = name_off,
+	};
+
+	if (fwrite(&ev, sizeof(ev), 1, torch_dump) == 1)
+		torch_event_cnt++;
+
+	*(void **)ret_slot = NULL;
+	return ret_slot;
+}
+
+/*
+ * RecordFunction end callback.
+ * C++ signature: void (*)(const RecordFunction&, ObserverContext*)
+ * Void return, two pointer args — trivially portable across ABIs.
+ */
+static void rf_end_cb(const void *record_fn, void *ctx)
+{
+	if (!torch_active || !torch_dump)
+		return;
+	if (!run_ctx->sess_start_ts)
+		return;
+
+	u64 ts = ktime_now_ns();
+	u32 tid = (u32)syscall(SYS_gettid);
+
+	struct wpytrace_event ev = {
+		.ts = ts,
+		.tid = tid,
+		.what = WPYTRACE_PYTORCH_EXIT,
+		.code_key = 0,
+		.rf_name_off = 0,
+	};
+
+	if (fwrite(&ev, sizeof(ev), 1, torch_dump) == 1)
+		torch_event_cnt++;
+}
+
+/*
+ * Call addGlobalCallback with a 40-byte struct passed by value.
+ *
+ * The C compiler handles the platform-specific calling convention for passing
+ * a 40-byte struct by value (stack on x86_64, indirect reference on aarch64).
+ * We cast the resolved symbol to a function pointer typed to take the struct
+ * by value, and the compiler does the rest.
+ */
+
+/* We define a wrapper struct that exactly matches the C++ layout */
+struct rf_callback_struct {
+	void *start;        /* 0  */
+	void *end;          /* 8  */
+	double prob;        /* 16 */
+	bool scopes[10];    /* 24 */
+	bool needs_inputs;  /* 34 */
+	bool needs_outputs; /* 35 */
+	bool needs_ids;     /* 36 */
+	u8 pad[3];          /* 37-39 */
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct rf_callback_struct) == 40,
+	       "rf_callback_struct must be 40 bytes");
+
+typedef u64 (*rf_add_cb_fn_t)(struct rf_callback_struct cb);
+
+static u64 rf_call_add_global_callback(const struct rf_callback_struct *cb)
+{
+	rf_add_cb_fn_t fn = (rf_add_cb_fn_t)rf_add_global_callback_ptr;
+	return fn(*cb);
+}
+
+/* RecordScope enum values from ATen/record_function.h */
+#define RF_SCOPE_FUNCTION          0
+#define RF_SCOPE_BACKWARD_FUNCTION 1
+#define RF_SCOPE_USER_SCOPE        7
+#define RF_SCOPE_COUNT             10
+
+static void rf_register(void)
+{
+	struct rf_callback_struct cb = {
+		.start = (void *)rf_start_cb,
+		.end = (void *)rf_end_cb,
+		.prob = 1.0,
+		.scopes = { [RF_SCOPE_FUNCTION] = true, [RF_SCOPE_BACKWARD_FUNCTION] = true, [RF_SCOPE_USER_SCOPE] = true },
+	};
+
+	rf_callback_handle = rf_call_add_global_callback(&cb);
+	rf_active = true;
+
+	vlog("RecordFunction callback registered (handle=%llu)\n", (unsigned long long)rf_callback_handle);
+}
+
+static void rf_unregister(void)
+{
+	if (!rf_active)
+		return;
+
+	if (rf_remove_callback) {
+		rf_remove_callback(rf_callback_handle);
+		vlog("RecordFunction callback unregistered (handle=%llu)\n",
+		     (unsigned long long)rf_callback_handle);
+	}
+
+	rf_active = false;
+}
+
+static int rf_resolve_symbols(void)
+{
+	/*
+	 * libtorch_cpu.so is loaded by Python's import machinery with RTLD_LOCAL,
+	 * so its C++ symbols aren't visible via RTLD_DEFAULT. We need to get a
+	 * handle to the already-loaded library using RTLD_NOLOAD.
+	 */
+	void *torch_handle = dlopen("libtorch_cpu.so", RTLD_NOLOAD | RTLD_LAZY);
+	if (!torch_handle) {
+		vlog("dlopen(libtorch_cpu.so, NOLOAD) failed: %s\n", dlerror());
+		return -ENOENT;
+	}
+
+	vlog("Got handle to libtorch_cpu.so at %p\n", torch_handle);
+
+	rf_add_global_callback_ptr = dlsym(torch_handle,
+		"_ZN2at17addGlobalCallbackENS_22RecordFunctionCallbackE");
+	rf_remove_callback = dlsym(torch_handle, "_ZN2at14removeCallbackEm");
+	rf_name = dlsym(torch_handle, "_ZNK2at14RecordFunction4nameEv");
+
+	if (rf_add_global_callback_ptr)
+		vlog("Resolved at::addGlobalCallback at %p\n", rf_add_global_callback_ptr);
+	if (rf_remove_callback)
+		vlog("Resolved at::removeCallback at %p\n", (void *)rf_remove_callback);
+	if (rf_name)
+		vlog("Resolved at::RecordFunction::name at %p\n", (void *)rf_name);
+
+	dlclose(torch_handle);
+
+	return rf_add_global_callback_ptr && rf_remove_callback && rf_name ? 0 : -ENOENT;
+}
+
+/* ==================== Dump file management ==================== */
+
+static void init_wpytrace_header(struct wpytrace_data_hdr *hdr)
+{
+	memset(hdr, 0, sizeof(*hdr));
+	memcpy(hdr->magic, "WPYFUNC", 8);
+	hdr->hdr_sz = sizeof(*hdr);
+}
+
+static int init_torch_data(FILE *dump)
+{
+	int err;
+
+	err = fseek(dump, 0, SEEK_SET);
+	if (err) {
+		err = -errno;
+		elog("Failed to fseek(0) torch data dump: %d\n", err);
+		return err;
+	}
+
+	struct wpytrace_data_hdr hdr;
+	init_wpytrace_header(&hdr);
+	hdr.flags = WPYTRACE_DATA_FLAG_INCOMPLETE;
+
+	if (fwrite(&hdr, sizeof(hdr), 1, dump) != 1) {
+		err = -errno;
+		elog("Failed to fwrite() torch data dump header: %d\n", err);
+		return err;
+	}
+
+	fflush(dump);
+	fsync(fileno(dump));
+	return 0;
+}
+
+/* ==================== Public API ==================== */
+
+int torch_profiler_setup(int dump_fd)
+{
+	int err = 0;
+
+	torch_dump_strs = strset__new(TORCH_DUMP_MAX_STRS_SZ, "", 1);
+	if (!torch_dump_strs) {
+		elog("Failed to create torch string set\n");
+		return -ENOMEM;
+	}
+
+	torch_dump = fdopen(dump_fd, "w");
+	if (!torch_dump) {
+		err = -errno;
+		elog("Failed to create FILE wrapper around torch dump FD %d: %d\n", dump_fd, err);
+		goto cleanup;
+	}
+	setvbuf(torch_dump, NULL, _IOFBF, TORCH_DUMP_BUF_SZ);
+
+	if ((err = init_torch_data(torch_dump)) < 0) {
+		elog("Failed to init torch dump: %d\n", err);
+		goto cleanup;
+	}
+
+	torch_active = true;
+
+	if ((err = rf_resolve_symbols()) < 0) {
+		elog("Failed to resolve PyTorch record function symbols");
+		goto cleanup;
+	}
+
+	rf_register();
+
+	return 0;
+
+cleanup:
+	torch_active = false;
+	strset__free(torch_dump_strs);
+	torch_dump_strs = NULL;
+	if (torch_dump) {
+		fclose(torch_dump);
+		torch_dump = NULL;
+	} else {
+		zclose(dump_fd);
+	}
+	return err;
+}
+
+int torch_profiler_teardown(void)
+{
+	int err = 0;
+
+	if (!torch_dump)
+		return 0;
+
+	rf_unregister();
+	torch_active = false;
+
+	fflush(torch_dump);
+
+	long events_end = ftell(torch_dump);
+	if (events_end < 0) {
+		err = -errno;
+		elog("Failed to get torch dump file position: %d\n", err);
+		return err;
+	}
+
+	/*
+	 * Torch dumps have no code_map (that's pytrace-only), so write
+	 * code_map_off/sz/cnt as zero and go straight to the string table.
+	 */
+
+	/* Write string table */
+	const char *strs = strset__data(torch_dump_strs);
+	size_t strs_sz = strset__data_size(torch_dump_strs);
+
+	long strs_off = ftell(torch_dump) - sizeof(struct wpytrace_data_hdr);
+	if (strs_sz > 0 && fwrite(strs, 1, strs_sz, torch_dump) != strs_sz) {
+		err = -errno;
+		elog("Failed to write torch strings: %d\n", err);
+		return err;
+	}
+
+	fsync(fileno(torch_dump));
+
+	/* Finalize header */
+	struct wpytrace_data_hdr hdr;
+	init_wpytrace_header(&hdr);
+
+	hdr.sess_start_ns = run_ctx->sess_start_ts;
+	hdr.sess_end_ns = run_ctx->sess_end_ts;
+	hdr.events_off = 0;
+	hdr.events_sz = events_end - sizeof(struct wpytrace_data_hdr);
+	hdr.event_cnt = torch_event_cnt;
+	hdr.code_map_off = 0;
+	hdr.code_map_sz = 0;
+	hdr.code_map_cnt = 0;
+	hdr.strs_off = strs_off;
+	hdr.strs_sz = strs_sz;
+
+	err = fseek(torch_dump, 0, SEEK_SET);
+	if (err) {
+		err = -errno;
+		elog("Failed to fseek(0) torch dump: %d\n", err);
+		return err;
+	}
+
+	if (fwrite(&hdr, sizeof(hdr), 1, torch_dump) != 1) {
+		err = -errno;
+		elog("Failed to fwrite() torch dump header: %d\n", err);
+		return err;
+	}
+
+	fflush(torch_dump);
+	fsync(fileno(torch_dump));
+
+	vlog("torch profiler finalized: %llu events, %zu string bytes\n",
+	     torch_event_cnt, strs_sz);
+
+	fclose(torch_dump);
+	torch_dump = NULL;
+
+	strset__free(torch_dump_strs);
+	torch_dump_strs = NULL;
+
+	return 0;
+}

--- a/src/inject.c
+++ b/src/inject.c
@@ -218,22 +218,22 @@ __unused
 static void log_regs(const struct tracee_state *tracee, const struct user_regs_struct *regs, const char *label)
 {
 #if defined(__x86_64__)
-	dlog("%s REGS (x86-64):\n", label);
-	dlog("  RIP=%016llx RSP=%016llx RBP=%016llx\n", regs->rip, regs->rsp, regs->rbp);
-	dlog("  RAX=%016llx RBX=%016llx RCX=%016llx RDX=%016llx\n", regs->rax, regs->rbx, regs->rcx, regs->rdx);
-	dlog("  RSI=%016llx RDI=%016llx\n", regs->rsi, regs->rdi);
-	dlog("  R8 =%016llx R9 =%016llx R10=%016llx R11=%016llx\n", regs->r8, regs->r9, regs->r10, regs->r11);
-	dlog("  R12=%016llx R13=%016llx R14=%016llx R15=%016llx\n", regs->r12, regs->r13, regs->r14, regs->r15);
-	dlog("  EFLAGS=%016llx ORIG_RAX=%016llx\n", regs->eflags, regs->orig_rax);
-	dlog("  CS=%04llx SS=%04llx DS=%04llx ES=%04llx FS=%04llx GS=%04llx\n", regs->cs, regs->ss, regs->ds, regs->es, regs->fs, regs->gs);
-	dlog("  FS_BASE=%016llx GS_BASE=%016llx\n", regs->fs_base, regs->gs_base);
+	ddlog("%s REGS (x86-64):\n", label);
+	ddlog("  RIP=%016llx RSP=%016llx RBP=%016llx\n", regs->rip, regs->rsp, regs->rbp);
+	ddlog("  RAX=%016llx RBX=%016llx RCX=%016llx RDX=%016llx\n", regs->rax, regs->rbx, regs->rcx, regs->rdx);
+	ddlog("  RSI=%016llx RDI=%016llx\n", regs->rsi, regs->rdi);
+	ddlog("  R8 =%016llx R9 =%016llx R10=%016llx R11=%016llx\n", regs->r8, regs->r9, regs->r10, regs->r11);
+	ddlog("  R12=%016llx R13=%016llx R14=%016llx R15=%016llx\n", regs->r12, regs->r13, regs->r14, regs->r15);
+	ddlog("  EFLAGS=%016llx ORIG_RAX=%016llx\n", regs->eflags, regs->orig_rax);
+	ddlog("  CS=%04llx SS=%04llx DS=%04llx ES=%04llx FS=%04llx GS=%04llx\n", regs->cs, regs->ss, regs->ds, regs->es, regs->fs, regs->gs);
+	ddlog("  FS_BASE=%016llx GS_BASE=%016llx\n", regs->fs_base, regs->gs_base);
 #elif defined(__aarch64__)
-	dlog("%s REGS (arm64):\n", label);
-	dlog("  PC=%016llx SP=%016llx PSTATE=%016llx\n", regs->pc, regs->sp, regs->pstate);
+	ddlog("%s REGS (arm64):\n", label);
+	ddlog("  PC=%016llx SP=%016llx PSTATE=%016llx\n", regs->pc, regs->sp, regs->pstate);
 	for (int i = 0; i < 28; i += 4) {
-		dlog("  X%-2d=%016llx X%-2d=%016llx X%-2d=%016llx X%-2d=%016llx\n", i, regs->regs[i], i+1, regs->regs[i+1], i+2, regs->regs[i+2], i+3, regs->regs[i+3]);
+		ddlog("  X%-2d=%016llx X%-2d=%016llx X%-2d=%016llx X%-2d=%016llx\n", i, regs->regs[i], i+1, regs->regs[i+1], i+2, regs->regs[i+2], i+3, regs->regs[i+3]);
 	}
-	dlog("  X%-2d=%016llx X%-2d=%016llx X%-2d=%016llx\n", 28, regs->regs[28], 29, regs->regs[29], 30, regs->regs[30]);
+	ddlog("  X%-2d=%016llx X%-2d=%016llx X%-2d=%016llx\n", 28, regs->regs[28], 29, regs->regs[29], 30, regs->regs[30]);
 #else
 #error "Unsupported architecture for register logging"
 #endif
@@ -281,12 +281,12 @@ static void log_syscall_info(const struct tracee_state *tracee, const char *labe
 
 	long ret = ptrace(PTRACE_GET_SYSCALL_INFO, tracee->pid, sizeof(info), &info);
 	if (ret < 0) {
-		dlog("ptrace(PTRACE_GET_SYSCALL_INFO) failed: %d\n", -errno);
+		ddlog("ptrace(PTRACE_GET_SYSCALL_INFO) failed: %d\n", -errno);
 		return;
 	}
 
-	dlog("%s SYSCALL_INFO:\n", label);
-	dlog("  op=%s arch=%s ip=0x%llx sp=0x%llx\n",
+	ddlog("%s SYSCALL_INFO:\n", label);
+	ddlog("  op=%s arch=%s ip=0x%llx sp=0x%llx\n",
 	     syscall_info_op_str(info.op), syscall_info_arch_str(info.arch),
 	     info.instruction_pointer, info.stack_pointer);
 
@@ -294,24 +294,24 @@ static void log_syscall_info(const struct tracee_state *tracee, const char *labe
 	case PTRACE_SYSCALL_INFO_NONE:
 		break;
 	case PTRACE_SYSCALL_INFO_ENTRY:
-		dlog("  nr=%lld (0x%llx)\n", info.entry.nr, info.entry.nr);
-		dlog("  args=[0x%llx, 0x%llx, 0x%llx, 0x%llx, 0x%llx, 0x%llx]\n",
+		ddlog("  nr=%lld (0x%llx)\n", info.entry.nr, info.entry.nr);
+		ddlog("  args=[0x%llx, 0x%llx, 0x%llx, 0x%llx, 0x%llx, 0x%llx]\n",
 		     info.entry.args[0], info.entry.args[1], info.entry.args[2],
 		     info.entry.args[3], info.entry.args[4], info.entry.args[5]);
 		break;
 	case PTRACE_SYSCALL_INFO_EXIT:
-		dlog("  rval=%lld (0x%llx) is_error=%d\n",
+		ddlog("  rval=%lld (0x%llx) is_error=%d\n",
 		     info.exit.rval, info.exit.rval, info.exit.is_error);
 		break;
 	case PTRACE_SYSCALL_INFO_SECCOMP:
-		dlog("  nr=%lld (0x%llx)\n", info.seccomp.nr, info.seccomp.nr);
-		dlog("  args=[0x%llx, 0x%llx, 0x%llx, 0x%llx, 0x%llx, 0x%llx]\n",
+		ddlog("  nr=%lld (0x%llx)\n", info.seccomp.nr, info.seccomp.nr);
+		ddlog("  args=[0x%llx, 0x%llx, 0x%llx, 0x%llx, 0x%llx, 0x%llx]\n",
 		     info.seccomp.args[0], info.seccomp.args[1], info.seccomp.args[2],
 		     info.seccomp.args[3], info.seccomp.args[4], info.seccomp.args[5]);
-		dlog("  ret_data=0x%x\n", info.seccomp.ret_data);
+		ddlog("  ret_data=0x%x\n", info.seccomp.ret_data);
 		break;
 	default:
-		dlog("  (unknown op 0x%x)\n", info.op);
+		ddlog("  (unknown op 0x%x)\n", info.op);
 		break;
 	}
 }

--- a/src/merge.c
+++ b/src/merge.c
@@ -17,6 +17,8 @@
 #include "pmu.h"
 #include "cuda.h"
 #include "cuda_data.h"
+#include "pytrace.h"
+#include "pytrace_data.h"
 #include "proc.h"
 #include "persist.h"
 #include "stacktrace.h"
@@ -117,6 +119,17 @@ static int wcuda_event_cmp(const void *a, const void *b)
 {
 	const struct wcuda_event *x = *(const struct wcuda_event **)a;
 	const struct wcuda_event *y = *(const struct wcuda_event **)b;
+
+	if (x->ts == y->ts)
+		return 0;
+
+	return (s64)(x->ts - y->ts) < 0 ? -1 : 1;
+}
+
+static int wpytrace_event_cmp(const void *a, const void *b)
+{
+	const struct wpytrace_event *x = *(const struct wpytrace_event **)a;
+	const struct wpytrace_event *y = *(const struct wpytrace_event **)b;
 
 	if (x->ts == y->ts)
 		return 0;
@@ -308,6 +321,88 @@ int wprof_merge_data(const char *workdir_name, struct worker_state *workers)
 		wcuda->next_rec = wcuda->rec_cnt > 0 ? wcuda->recs[0] : NULL;
 	}
 
+	/* Prepare per-process pytrace event streams */
+	struct wpytrace_state {
+		struct wpytrace_data_hdr *dump_hdr;
+		size_t dump_sz;
+		const char *strs;
+		struct wpytrace_code_entry *code_map;
+		u64 code_map_cnt;
+		const struct wpytrace_event **recs;
+		const struct wpytrace_event *next_rec;
+		u64 rec_cnt;
+		u64 rec_idx;
+	} *wpytraces = calloc(env.pytrace_cnt, sizeof(*wpytraces));
+
+	for (int i = 0; i < env.pytrace_cnt; i++) {
+		struct pytrace_tracee *pf = &env.pytraces[i];
+		struct wpytrace_state *wpf = &wpytraces[i];
+
+		if (pf->state == TRACEE_INACTIVE) {
+			/* expected clean shutdown case */
+		} else if (pf->state == TRACEE_SHUTDOWN_TIMEOUT) {
+			eprintf("PyTrace tracee #%d (%s) timed out its shutdown, but we'll try to collect its data nevertheless!..\n",
+				i, pytrace_str(pf));
+		} else {
+			eprintf("Skipping pytrace tracing data from tracee #%d (%s) as it had problems...\n",
+				i, pytrace_str(pf));
+			continue;
+		}
+
+		/* Load pytrace dump and optionally torch dump into wpytraces[] */
+		int dump_fds[] = { pf->dump_fd, pf->torch_dump_fd };
+		const char *dump_paths[] = { pf->dump_path, pf->torch_dump_path };
+		const char *dump_labels[] = { "pytrace", "torch" };
+
+		for (int d = 0; d < ARRAY_SIZE(dump_fds); d++) {
+			if (dump_fds[d] < 0)
+				continue;
+
+			struct wpytrace_state *wpf = &wpytraces[wpytrace_cnt];
+
+			struct stat st;
+			if (fstat(dump_fds[d], &st) < 0) {
+				err = -errno;
+				eprintf("Failed to fstat() %s data dump for tracee %s at '%s': %d\n",
+					dump_labels[d], pytrace_str(pf), dump_paths[d], err);
+				continue;
+			}
+
+			wpf->dump_sz = st.st_size;
+			wpf->dump_hdr = mmap(NULL, wpf->dump_sz, PROT_READ | PROT_WRITE, MAP_SHARED, dump_fds[d], 0);
+			if (wpf->dump_hdr == MAP_FAILED) {
+				err = -errno;
+				eprintf("Failed to mmap() %s data dump for tracee %s at '%s': %d\n",
+					dump_labels[d], pytrace_str(pf), dump_paths[d], err);
+				wpf->dump_hdr = NULL;
+				continue;
+			}
+
+			wpf->strs = (void *)wpf->dump_hdr + wpf->dump_hdr->hdr_sz + wpf->dump_hdr->strs_off;
+			wpf->code_map = (void *)wpf->dump_hdr + wpf->dump_hdr->hdr_sz + wpf->dump_hdr->code_map_off;
+			wpf->code_map_cnt = wpf->dump_hdr->code_map_cnt;
+			qsort(wpf->code_map, wpf->code_map_cnt, sizeof(*wpf->code_map), wpytrace_code_entry_cmp);
+			wpf->tracee_idx = i;
+
+			/* Collect event pointers and sort by converted timestamp */
+			wpf->rec_idx = 0;
+			wpf->rec_cnt = wpf->dump_hdr->event_cnt;
+			wpf->recs = calloc(wpf->rec_cnt, sizeof(*wpf->recs));
+
+			struct wpytrace_event_record *rec;
+			u64 idx = 0;
+			wpytrace_for_each_event(rec, wpf->dump_hdr) {
+				wpf->recs[idx++] = rec->e;
+			}
+
+			qsort(wpf->recs, wpf->rec_cnt, sizeof(*wpf->recs), wpytrace_event_cmp);
+
+			wpf->next_rec = wpf->rec_cnt > 0 ? wpf->recs[0] : NULL;
+
+			wpytrace_cnt++;
+		}
+	}
+
 	/* Merge and convert events in timestamp order */
 	struct wevent wevent_buf;
 	while (true) {
@@ -331,6 +426,16 @@ int wprof_merge_data(const char *workdir_name, struct worker_state *workers)
 			/* find event with smallest timestamp */
 			if (widx < 0 || (s64)(r->ts - ts) < 0) {
 				widx = env.ringbuf_cnt + i;
+				ts = r->ts;
+			}
+		}
+		for (int i = 0; i < env.pytrace_cnt; i++) {
+			const struct wpytrace_event *r = wpytraces[i].next_rec;
+			if (!r)
+				continue;
+			/* timestamps already converted to ns in-place */
+			if (widx < 0 || (s64)(r->ts - ts) < 0) {
+				widx = env.ringbuf_cnt + env.cuda_cnt + i;
 				ts = r->ts;
 			}
 		}
@@ -362,7 +467,7 @@ int wprof_merge_data(const char *workdir_name, struct worker_state *workers)
 			 */
 			if (wevent_sz == 0)
 				continue;
-		} else {
+		} else if (widx < env.ringbuf_cnt + env.cuda_cnt) {
 			int cidx = widx - env.ringbuf_cnt;
 
 			struct wcuda_state *wcuda = &wcudas[cidx];
@@ -378,6 +483,27 @@ int wprof_merge_data(const char *workdir_name, struct worker_state *workers)
 
 			wcuda->rec_idx++;
 			wcuda->next_rec = wcuda->rec_idx < wcuda->rec_cnt ? wcuda->recs[wcuda->rec_idx] : NULL;
+		} else {
+			int pidx = widx - env.ringbuf_cnt - env.cuda_cnt;
+
+			struct wpytrace_state *wpf = &wpytraces[pidx];
+			const struct wpytrace_event *r = wpf->next_rec;
+			struct pytrace_tracee *pf = &env.pytraces[pidx];
+
+			wevent_sz = persist_pytrace_event(&ps, r, &wevent_buf, wpf->dump_hdr,
+							 pf->pid, pf->proc_name,
+							 wpf->code_map, wpf->code_map_cnt,
+							 wpf->strs);
+			if (wevent_sz < 0) {
+				eprintf("Failed to convert pytrace event for tracee %s: %d\n", pytrace_str(pf), wevent_sz);
+				return wevent_sz;
+			}
+
+			wpf->rec_idx++;
+			wpf->next_rec = wpf->rec_idx < wpf->rec_cnt ? wpf->recs[wpf->rec_idx] : NULL;
+
+			if (wevent_sz == 0)
+				continue;
 		}
 
 		event_cnt += 1;
@@ -388,11 +514,16 @@ int wprof_merge_data(const char *workdir_name, struct worker_state *workers)
 			if (widx < env.ringbuf_cnt) {
 				eprintf("Failed to fwrite() event from ringbuf #%d ('%s'): %d\n",
 					widx, workers[widx].dump_path, err);
-			} else {
+			} else if (widx < env.ringbuf_cnt + env.cuda_cnt) {
 				int cidx = widx - env.ringbuf_cnt;
 				struct cuda_tracee *cuda = &env.cudas[cidx];
 				eprintf("Failed to fwrite() event from CUDA tracee %s: %d\n",
 					cuda_str(cuda), err);
+			} else {
+				int pidx = widx - env.ringbuf_cnt - env.cuda_cnt;
+				struct pytrace_tracee *pf = &env.pytraces[pidx];
+				eprintf("Failed to fwrite() event from pytrace tracee %s: %d\n",
+					pytrace_str(pf), err);
 			}
 			return err;
 		}
@@ -440,6 +571,28 @@ int wprof_merge_data(const char *workdir_name, struct worker_state *workers)
 		w->dump_sz = 0;
 	}
 	free(wcudas);
+
+	/* Cleanup pytrace dumps */
+	for (int i = 0; i < env.pytrace_cnt; i++) {
+		struct pytrace_tracee *pf = &env.pytraces[i];
+		struct wpytrace_state *wpf = &wpytraces[i];
+
+		if (wpf->dump_hdr)
+			munmap(wpf->dump_hdr, wpf->dump_sz);
+
+		if (!env.keep_workdir && pf->dump_path)
+			unlink(pf->dump_path);
+
+		free(pf->dump_path);
+		pf->dump_path = NULL;
+
+		zclose(pf->dump_fd);
+
+		free(wpf->recs);
+		wpf->dump_hdr = NULL;
+		wpf->dump_sz = 0;
+	}
+	free(wpytraces);
 
 	/* Write thread table section */
 	file_pad(data_dump, 8);

--- a/src/merge.c
+++ b/src/merge.c
@@ -332,11 +332,20 @@ int wprof_merge_data(const char *workdir_name, struct worker_state *workers)
 		const struct wpytrace_event *next_rec;
 		u64 rec_cnt;
 		u64 rec_idx;
-	} *wpytraces = calloc(env.pytrace_cnt, sizeof(*wpytraces));
+		int tracee_idx; /* index into env.pytraces[] */
+	};
+
+	/*
+	 * Each pytrace tracee can produce up to 2 dump files: the pytrace dump
+	 * and an optional torch profiler dump. We allocate double the entries
+	 * and fill in both when the torch dump exists.
+	 */
+	int wpytrace_cnt = 0;
+	int wpytrace_cap = env.pytrace_cnt * 2;
+	struct wpytrace_state *wpytraces = calloc(wpytrace_cap, sizeof(*wpytraces));
 
 	for (int i = 0; i < env.pytrace_cnt; i++) {
 		struct pytrace_tracee *pf = &env.pytraces[i];
-		struct wpytrace_state *wpf = &wpytraces[i];
 
 		if (pf->state == TRACEE_INACTIVE) {
 			/* expected clean shutdown case */
@@ -429,7 +438,7 @@ int wprof_merge_data(const char *workdir_name, struct worker_state *workers)
 				ts = r->ts;
 			}
 		}
-		for (int i = 0; i < env.pytrace_cnt; i++) {
+		for (int i = 0; i < wpytrace_cnt; i++) {
 			const struct wpytrace_event *r = wpytraces[i].next_rec;
 			if (!r)
 				continue;
@@ -488,7 +497,7 @@ int wprof_merge_data(const char *workdir_name, struct worker_state *workers)
 
 			struct wpytrace_state *wpf = &wpytraces[pidx];
 			const struct wpytrace_event *r = wpf->next_rec;
-			struct pytrace_tracee *pf = &env.pytraces[pidx];
+			struct pytrace_tracee *pf = &env.pytraces[wpf->tracee_idx];
 
 			wevent_sz = persist_pytrace_event(&ps, r, &wevent_buf, wpf->dump_hdr,
 							 pf->pid, pf->proc_name,
@@ -521,7 +530,8 @@ int wprof_merge_data(const char *workdir_name, struct worker_state *workers)
 					cuda_str(cuda), err);
 			} else {
 				int pidx = widx - env.ringbuf_cnt - env.cuda_cnt;
-				struct pytrace_tracee *pf = &env.pytraces[pidx];
+				struct wpytrace_state *wpf = &wpytraces[pidx];
+				struct pytrace_tracee *pf = &env.pytraces[wpf->tracee_idx];
 				eprintf("Failed to fwrite() event from pytrace tracee %s: %d\n",
 					pytrace_str(pf), err);
 			}
@@ -572,25 +582,32 @@ int wprof_merge_data(const char *workdir_name, struct worker_state *workers)
 	}
 	free(wcudas);
 
-	/* Cleanup pytrace dumps */
-	for (int i = 0; i < env.pytrace_cnt; i++) {
-		struct pytrace_tracee *pf = &env.pytraces[i];
+	/* Cleanup pytrace and torch dumps */
+	for (int i = 0; i < wpytrace_cnt; i++) {
 		struct wpytrace_state *wpf = &wpytraces[i];
 
 		if (wpf->dump_hdr)
 			munmap(wpf->dump_hdr, wpf->dump_sz);
 
-		if (!env.keep_workdir && pf->dump_path)
-			unlink(pf->dump_path);
-
-		free(pf->dump_path);
-		pf->dump_path = NULL;
-
-		zclose(pf->dump_fd);
-
 		free(wpf->recs);
 		wpf->dump_hdr = NULL;
 		wpf->dump_sz = 0;
+	}
+	for (int i = 0; i < env.pytrace_cnt; i++) {
+		struct pytrace_tracee *pf = &env.pytraces[i];
+
+		if (!env.keep_workdir && pf->dump_path)
+			unlink(pf->dump_path);
+		if (!env.keep_workdir && pf->torch_dump_path)
+			unlink(pf->torch_dump_path);
+
+		free(pf->dump_path);
+		pf->dump_path = NULL;
+		free(pf->torch_dump_path);
+		pf->torch_dump_path = NULL;
+
+		zclose(pf->dump_fd);
+		zclose(pf->torch_dump_fd);
 	}
 	free(wpytraces);
 

--- a/src/persist.c
+++ b/src/persist.c
@@ -554,6 +554,13 @@ int persist_pytrace_event(struct persist_state *ps, const struct wpytrace_event 
 	dst->numa_node = 0;
 	dst->ts = e->ts;
 
+	if (e->what == WPYTRACE_PYTORCH_ENTRY || e->what == WPYTRACE_PYTORCH_EXIT) {
+		dst->sz = WEVENT_SZ(rf);
+		dst->kind = (e->what == WPYTRACE_PYTORCH_ENTRY) ? EV_PYTORCH_ENTRY : EV_PYTORCH_EXIT;
+		dst->rf.name_stroff = e->rf_name_off ? persist_stroff(ps, pytrace_strs + e->rf_name_off) : 0;
+		return dst->sz;
+	}
+
 	enum event_kind kind = (e->what == 0) ? EV_PYTRACE_ENTRY : EV_PYTRACE_EXIT;
 	dst->sz = WEVENT_SZ(pytrace);
 	dst->kind = kind;

--- a/src/persist.c
+++ b/src/persist.c
@@ -11,6 +11,7 @@
 #include "utils.h"
 #include "pmu.h"
 #include "cuda_data.h"
+#include "pytrace_data.h"
 #include "proc.h"
 #include "../libbpf/src/strset.h"
 #include "../libbpf/src/hashmap.h"
@@ -525,6 +526,47 @@ int persist_cuda_event(struct persist_state *ps, const struct wcuda_event *e, st
 	default:
 		eprintf("Unrecognized CUDA event type %d while persisting!\n", e->kind);
 		return -EINVAL;
+	}
+
+	return dst->sz;
+}
+
+static const struct wpytrace_code_entry *lookup_pytrace_code(const struct wpytrace_code_entry *code_map,
+							     u64 code_map_cnt, u64 code_key)
+{
+	struct wpytrace_code_entry key = { .code_key = code_key };
+	return bsearch(&key, code_map, code_map_cnt, sizeof(*code_map), wpytrace_code_entry_cmp);
+}
+
+int persist_pytrace_event(struct persist_state *ps, const struct wpytrace_event *e, struct wevent *dst,
+			 const struct wpytrace_data_hdr *hdr, int host_pid, const char *proc_name,
+			 const struct wpytrace_code_entry *code_map, u64 code_map_cnt,
+			 const char *pytrace_strs)
+{
+	/* Resolve TID -- pytrace events use host-level TIDs directly */
+	struct tid_cache_value *ti = resolve_cuda_host_tid(ps, host_pid, proc_name, host_pid, e->tid);
+	if (!ti)
+		return 0;
+
+	dst->flags = 0;
+	dst->task_id = ti->task_id;
+	dst->cpu = 0;
+	dst->numa_node = 0;
+	dst->ts = e->ts;
+
+	enum event_kind kind = (e->what == 0) ? EV_PYTRACE_ENTRY : EV_PYTRACE_EXIT;
+	dst->sz = WEVENT_SZ(pytrace);
+	dst->kind = kind;
+
+	const struct wpytrace_code_entry *ce = lookup_pytrace_code(code_map, code_map_cnt, e->code_key);
+	if (ce) {
+		dst->pytrace.func_name_stroff = persist_stroff(ps, pytrace_strs + ce->func_name_off);
+		dst->pytrace.file_name_stroff = persist_stroff(ps, pytrace_strs + ce->file_name_off);
+		dst->pytrace.lineno = ce->lineno;
+	} else {
+		dst->pytrace.func_name_stroff = persist_stroff(ps, "<unknown>");
+		dst->pytrace.file_name_stroff = 0;
+		dst->pytrace.lineno = 0;
 	}
 
 	return dst->sz;

--- a/src/persist.h
+++ b/src/persist.h
@@ -6,6 +6,7 @@
 #include "wprof_types.h"
 #include "wprof.h"
 #include "cuda_data.h"
+#include "pytrace_data.h"
 #include "wevent.h"
 #include "pmu.h"
 
@@ -45,5 +46,9 @@ int persist_add_pmu_def(struct persist_state *ps, const struct pmu_event *ev);
 int persist_bpf_event(struct persist_state *ps, const struct wprof_event *e, struct wevent *dst);
 int persist_cuda_event(struct persist_state *ps, const struct wcuda_event *e, struct wevent *dst,
 		       int host_pid, const char *proc_name, const char *cuda_strs);
+int persist_pytrace_event(struct persist_state *ps, const struct wpytrace_event *e, struct wevent *dst,
+			 const struct wpytrace_data_hdr *hdr, int host_pid, const char *proc_name,
+			 const struct wpytrace_code_entry *code_map, u64 code_map_cnt,
+			 const char *pytrace_strs);
 
 #endif /* __PERSIST_H_ */

--- a/src/protobuf.c
+++ b/src/protobuf.c
@@ -172,6 +172,7 @@ static const char *pb_static_strs[] = {
 	[IID_CAT_CUDA_MEMSET] = "CUDA_MEMSET",
 	[IID_CAT_CUDA_SYNC] = "CUDA_SYNC",
 	[IID_CAT_SCX_DSQ] = "SCX_DSQ",
+	[IID_CAT_PYTRACE] = "PYTRACE",
 
 	[IID_NAME_TIMER] = "TIMER",
 	[IID_NAME_EXEC] = "EXEC",
@@ -304,6 +305,8 @@ static const char *pb_static_strs[] = {
 	[IID_ANNK_CUDA_EVENT_ID] = "event_id",
 	[IID_ANNK_CUDA_MANGLED_NAME] = "mangled_name",
 	[IID_ANNK_CUDA_GPU_DELAY_US] = "gpu_delay_us",
+	[IID_ANNK_PYTRACE_FILE] = "file",
+	[IID_ANNK_PYTRACE_LINENO] = "lineno",
 
 	[IID_ANNV_SOFTIRQ_ACTION + HI_SOFTIRQ] = "hi",
 	[IID_ANNV_SOFTIRQ_ACTION + TIMER_SOFTIRQ] = "timer",

--- a/src/protobuf.h
+++ b/src/protobuf.h
@@ -144,6 +144,7 @@ enum pb_static_iid {
 		IID_CAT_CUDA_MEMSET, 				/* CUDA_MEMSET */
 		IID_CAT_CUDA_SYNC,				/* CUDA_SYNC */
 		IID_CAT_SCX_DSQ,				/* SCX_DSQ */
+		IID_CAT_PYTRACE,				/* PYTRACE */
 	CAT_END_IID,
 
 	NAME_START_IID, __NAME_RESET_IID = NAME_START_IID - 1,
@@ -250,6 +251,8 @@ enum pb_static_iid {
 		IID_ANNK_CUDA_EVENT_ID,				/* event_id */
 		IID_ANNK_CUDA_MANGLED_NAME,			/* mangled_name */
 		IID_ANNK_CUDA_GPU_DELAY_US,			/* gpu_delay_us */
+		IID_ANNK_PYTRACE_FILE,				/* file */
+		IID_ANNK_PYTRACE_LINENO,			/* lineno */
 	ANNK_END_IID,
 
 	ANNV_START_IID, __ANNV_RESET_IID = ANNV_START_IID - 1,

--- a/src/pydisc.c
+++ b/src/pydisc.c
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /* Copyright (c) 2026 Meta Platforms, Inc. */
 #define _GNU_SOURCE
-#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
 #include <elf.h>
 #include <linux/fs.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
 
 #include <bpf/bpf.h>
 
@@ -15,10 +16,23 @@
 #include "env.h"
 #include "proc.h"
 #include "elf_utils.h"
+#include "pydisc.h"
 
 #include "strobelight/bpf_lib/python/include/PyPidData.h"
 
 #include "wprof.skel.h"
+
+int py_read_elf_version(const char *binary_path, int *major, int *minor)
+{
+	unsigned long ver;
+
+	if (elf_read_sym_value(binary_path, "Py_Version", STT_OBJECT, &ver, sizeof(ver)) != 0)
+		return -ENOENT;
+
+	*major = (ver >> 24) & 0xFF;
+	*minor = (ver >> 16) & 0xFF;
+	return 0;
+}
 
 struct py_tracee {
 	int pid;
@@ -72,99 +86,56 @@ static bool has_pyruntime_sym(const char *binary_path)
 }
 
 /*
- * Extract Python major.minor version from the ELF Py_Version symbol.
- * CPython 3.11+ exports Py_Version as (major << 24) | (minor << 16) | ...
- * If the symbol is absent (Python 3.10 and earlier), default to 3.10 —
- * the only pre-3.11 version we support.
- */
-static void extract_version_from_elf(const char *binary_path, int *major, int *minor)
-{
-	unsigned long ver;
-
-	if (elf_read_sym_value(binary_path, "Py_Version", STT_OBJECT, &ver, sizeof(ver)) == 0) {
-		*major = (ver >> 24) & 0xFF;
-		*minor = (ver >> 16) & 0xFF;
-	} else {
-		*major = 3;
-		*minor = 10;
-	}
-}
-
-/*
- * Find the Python runtime binary for a process. This is the binary or shared
- * library that contains the _PyRuntime symbol. On systems with dynamically
- * linked Python, this is typically libpython3.X.so rather than the python3
- * executable itself.
+ * Find the Python binary for a process and compute its load base address.
+ * Checks the main executable first (statically-linked Python, e.g. fbpython),
+ * then scans loaded libpython*.so shared libraries.
  *
- * Returns 0 if found (binary_path and base_addr set), -ENOENT if not Python.
+ * Returns 0 if found (bi populated), -ENOENT if not Python.
  */
-static int find_python_runtime(int pid, char *binary_path, size_t path_sz,
-			       unsigned long *base_addr, int *py_major, int *py_minor)
+int py_find_binary(int pid, struct py_binary_info *bi)
 {
-	struct vma_info *vma;
 	char exe_path[PATH_MAX];
-	char resolved[PATH_MAX];
-	ssize_t len;
+	struct vma_info *vma;
+	struct stat st;
+	__u64 last_dev = 0;
+	__u64 last_inode = 0;
 
-	*base_addr = 0;
+	memset(bi, 0, sizeof(*bi));
 
-	/*
-	 * Find where _PyRuntime lives:
-	 * 1. In the executable itself (statically linked Python, e.g. python3)
-	 * 2. In libpython*.so (dynamically linked, covers both python3 and
-	 *    custom binaries like Cinder's trainer_main)
-	 */
-
-	/* try the executable first (statically linked Python) */
 	snprintf(exe_path, sizeof(exe_path), "/proc/%d/exe", pid);
-	len = readlink(exe_path, resolved, sizeof(resolved) - 1);
-	if (len > 0) {
-		resolved[len] = '\0';
-		if (has_pyruntime_sym(exe_path)) {
-			extract_version_from_elf(exe_path, py_major, py_minor);
-			snprintf(binary_path, path_sz, "%s", exe_path);
-			/* Use the first private VMA for this binary to compute
-			 * base_addr. Skip shared VMAs — those are mmap(MAP_SHARED)
-			 * from package managers, not ELF PT_LOAD mappings. The
-			 * first private VMA corresponds to the first PT_LOAD
-			 * segment (offset=0), giving correct load_bias. */
-			wprof_for_each(vma, vma, pid, VMA_QUERY_FILE_BACKED_VMA) {
-				if (vma->vma_flags & PROCMAP_QUERY_VMA_SHARED)
-					continue;
-				if (strcmp(vma->vma_name, resolved) == 0) {
-					*base_addr = vma->vma_start - vma->vma_offset;
-					break;
-				}
-			}
-			return 0;
-		}
+
+	if (stat(exe_path, &st)) {
+		eprintf("Railed to retrive file status for %s\n", exe_path);
+		return -errno;
 	}
-
-	/* Scan maps for libpython*.so with _PyRuntime. Don't filter by
-	 * VMA_QUERY_VMA_EXECUTABLE — we want the first VMA (first PT_LOAD)
-	 * for correct base_addr with -z separate-code ELFs. Skip shared VMAs —
-	 * those are mmap(MAP_SHARED) from package managers, not ELF loads. */
+	/* Scan static executable or libpython*.so for Py_Version (or _PyRuntime for 3.10).
+	 * Use first private VMA for correct base_addr. */
 	wprof_for_each(vma, vma, pid, VMA_QUERY_FILE_BACKED_VMA) {
-		char host_path[PATH_MAX];
-
 		if (vma->vma_flags & PROCMAP_QUERY_VMA_SHARED)
 			continue;
-
 		if (vma->vma_name[0] != '/')
 			continue;
 
-		if (!strstr(vma->vma_name, "/libpython") || !strstr(vma->vma_name, ".so"))
+		__u64 curr_dev = makedev(vma->dev_major, vma->dev_minor);
+
+		/* we already checked this binary */
+		if (vma->inode == last_inode && curr_dev == last_dev)
 			continue;
 
-		snprintf(host_path, sizeof(host_path), "/proc/%d/map_files/%llx-%llx",
+		last_inode = vma->inode;
+		last_dev = curr_dev;
+
+		snprintf(bi->host_path, sizeof(bi->host_path), "/proc/%d/map_files/%llx-%llx",
 			 pid, (unsigned long long)vma->vma_start, (unsigned long long)vma->vma_end);
+		bi->base_addr = vma->vma_start - vma->vma_offset;
 
-		if (!has_pyruntime_sym(host_path))
+		/* assume 3.10, unless we find elf version symbol */
+		bi->py_major = 3;
+		bi->py_minor = 10;
+
+		if (py_read_elf_version(bi->host_path, &bi->py_major, &bi->py_minor) < 0 &&
+				!has_pyruntime_sym(bi->host_path))
 			continue;
-
-		snprintf(binary_path, path_sz, "%s", host_path);
-		*base_addr = vma->vma_start - vma->vma_offset;
-		extract_version_from_elf(host_path, py_major, py_minor);
 		return 0;
 	}
 
@@ -257,43 +228,41 @@ static int setup_pid(int pid, const char *binary_path, unsigned long base_addr,
  */
 static int discover_pid(int pid, struct wprof_bpf *skel, bool force)
 {
-	char binary_path[PATH_MAX];
-	unsigned long base_addr;
-	int py_major, py_minor;
+	struct py_binary_info bi;
 	int err;
 
 	if (is_py_tracee(pid))
 		return 0;
 
-	err = find_python_runtime(pid, binary_path, sizeof(binary_path), &base_addr, &py_major, &py_minor);
+	err = py_find_binary(pid, &bi);
 	if (err) {
 		if (force)
 			eprintf("PID %d (%s) does not appear to be a Python process\n", pid, proc_name(pid));
 		return err == -ENOENT ? 1 : err;
 	}
 
-	if (py_major != 3 || py_minor < 10) {
+	if (bi.py_major != 3 || bi.py_minor < 10) {
 		if (force)
 			eprintf("PID %d (%s): Python %d.%d is not supported (need 3.10+)\n",
-				pid, proc_name(pid), py_major, py_minor);
+				pid, proc_name(pid), bi.py_major, bi.py_minor);
 		else
 			vprintf("PID %d (%s): Python %d.%d is not supported (need 3.10+), skipping\n",
-				pid, proc_name(pid), py_major, py_minor);
+				pid, proc_name(pid), bi.py_major, bi.py_minor);
 		return -EOPNOTSUPP;
 	}
 
-	err = setup_pid(pid, binary_path, base_addr, py_major, py_minor, skel);
+	err = setup_pid(pid, bi.host_path, bi.base_addr, bi.py_major, bi.py_minor, skel);
 	if (err) {
 		eprintf("Failed to set up Python stack tracing for PID %d (%s): %d\n", pid, proc_name(pid), err);
 		return err;
 	}
 
-	err = add_py_tracee(pid, py_major, py_minor, binary_path);
+	err = add_py_tracee(pid, bi.py_major, bi.py_minor, bi.host_path);
 	if (err)
 		return err;
 
 	vprintf("Discovered Python %d.%d process PID=%d (%s) binary='%s'\n",
-		py_major, py_minor, pid, proc_name(pid), binary_path);
+		bi.py_major, bi.py_minor, pid, proc_name(pid), bi.host_path);
 	return 0;
 }
 

--- a/src/pydisc.h
+++ b/src/pydisc.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright (c) 2026 Meta Platforms, Inc. */
+#ifndef __PYDISC_H_
+#define __PYDISC_H_
+
+#include <linux/limits.h>
+
+struct py_binary_info {
+	char host_path[PATH_MAX];
+	unsigned long base_addr;
+	int py_major;
+	int py_minor;
+};
+
+int py_find_binary(int pid, struct py_binary_info *bi);
+int pydisc_py_minor(int pid);
+
+struct wprof_bpf;
+int pydisc_discover(struct wprof_bpf *skel);
+
+#endif /* __PYDISC_H_ */

--- a/src/pystacks.c
+++ b/src/pystacks.c
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /* Copyright (c) 2026 Meta Platforms, Inc. */
 #include "pystacks.h"
+#include "pydisc.h"
 #include "env.h"
 #include "utils.h"
 
 #include "wprof.skel.h"
-
-int pydisc_discover(struct wprof_bpf *skel);
 
 int pystacks_init(struct wprof_bpf *skel)
 {

--- a/src/pysym.c
+++ b/src/pysym.c
@@ -10,6 +10,7 @@
 
 #include "pysym.h"
 #include "pyline.h"
+#include "pydisc.h"
 #include "utils.h"
 
 /* matches strobelight-libs BPF_LIB_DEFAULT_MAP_SIZE */
@@ -19,9 +20,6 @@
 #define PYSYM_QUAL_NAME_LEN 224
 
 #define PYSYM_MAX_LINETABLE_SIZE (1 * 1024 * 1024)
-
-/* declared in pydisc.c */
-int pydisc_py_minor(int pid);
 
 struct pysym_entry {
 	char filename[PYSYM_FILE_NAME_LEN];

--- a/src/pytrace.c
+++ b/src/pytrace.c
@@ -1,0 +1,472 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2026 Meta Platforms, Inc. */
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <linux/fs.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+
+#include "pytrace.h"
+#include "cuda.h"
+#include "proc.h"
+#include "env.h"
+#include "sys.h"
+#include "inj_common.h"
+#include "inject.h"
+#include "elf_utils.h"
+
+#define LIBWPROFINJ_PYTRACE_LOG_PATH_FMT "wprofinj-pytrace-log.%d.%d.log"
+#define LIBWPROFINJ_PYTRACE_DUMP_PATH_FMT "wprofinj-pytrace.%d.%d.data"
+
+static const char *pytrace_proc_str(int pid, int ns_pid, const char *proc_name)
+{
+	static char buf[128];
+
+	if (pid == ns_pid)
+		snprintf(buf, sizeof(buf), "%d, %s", pid, proc_name);
+	else
+		snprintf(buf, sizeof(buf), "%d=%d, %s", pid, ns_pid, proc_name);
+
+	return buf;
+}
+
+const char *pytrace_str(const struct pytrace_tracee *t)
+{
+	return pytrace_proc_str(t->pid, t->ns_pid, t->proc_name);
+}
+
+static struct pytrace_tracee *add_pytrace_tracee(struct tracee_state *tracee)
+{
+	const struct tracee_info *info = tracee_info(tracee);
+	struct pytrace_tracee *pf;
+
+	env.pytraces = realloc(env.pytraces, (env.pytrace_cnt + 1) * sizeof(*env.pytraces));
+
+	pf = &env.pytraces[env.pytrace_cnt];
+	memset(pf, 0, sizeof(*pf));
+
+	pf->pid = info->pid;
+	pf->ns_pid = info->ns_pid;
+	pf->proc_name = info->name;
+	pf->uds_fd = info->uds_fd;
+	pf->tracee = tracee;
+	pf->ctx = info->run_ctx;
+
+	pf->log_fd = -1;
+	pf->dump_fd = -1;
+
+	env.pytrace_cnt++;
+
+	return pf;
+}
+
+/*
+ * Resolve pytrace Python C API symbols from the binary using elf_find_syms.
+ * Computes runtime addresses (base_addr + offset) for each symbol.
+ * Returns 0 on success, -ENOENT if any required symbol is missing.
+ */
+static int pytrace_resolve_symbols(int pid, struct py_binary_info *bi, unsigned long *sym_addrs)
+{
+	long offsets[PYTRACE_SYM_CNT] = {};
+	int err;
+
+	err = elf_find_syms(bi->host_path, STT_FUNC, pytrace_sym_names, offsets, PYTRACE_SYM_CNT);
+	if (err) {
+		for (int i = 0; i < PYTRACE_SYM_CNT; i++) {
+			if (offsets[i])
+				continue;
+			/* PyEval_SetProfileAllThreads is 3.12+ only */
+			if (strcmp(pytrace_sym_names[i], "PyEval_SetProfileAllThreads") == 0) {
+				vprintf("PID %d: %s not found, skipping\n", pid, pytrace_sym_names[i]);
+				continue;
+			}
+			eprintf("PID %d: missing required Python symbol[%s] in %s\n", pid, pytrace_sym_names[i], bi->host_path);
+			return -ENOENT;
+		}
+	}
+
+	for (int i = 0; i < PYTRACE_SYM_CNT; i++) {
+		sym_addrs[i] = offsets[i] ? bi->base_addr + offsets[i] : 0;
+		if (offsets[i])
+			dlogf(PYTRACE, 1, "  %s: offset=0x%lx addr=0x%lx\n", pytrace_sym_names[i], offsets[i], sym_addrs[i]);
+	}
+
+	return 0;
+}
+
+static int try_inject_to_python_process(int pid, int workdir_fd)
+{
+	struct py_binary_info bi;
+	unsigned long sym_addrs[PYTRACE_SYM_CNT] = {};
+	char log_path[128];
+	int err = 0, log_fd = -1;
+
+	err = py_find_binary(pid, &bi);
+	if (err) {
+		dlogf(PYTRACE, 1, "PID %d (%s) is not Python, skipping\n", pid, proc_name(pid));
+		return -ENOENT;
+	}
+
+	vprint("Process %s is Python 3.%d!\n",
+	      pytrace_proc_str(pid, ns_tid_by_host_tid(pid, pid), proc_name(pid)), bi.py_version_minor);
+
+	dlogf(PYTRACE, 0, "PID %d: Python binary at '%s', base_addr=0x%lx\n", pid, bi.host_path, bi.base_addr);
+
+	/* Resolve all required Python C API symbols before injection */
+	err = pytrace_resolve_symbols(pid, &bi, sym_addrs);
+	if (err) {
+		eprintf("Failed to resolve Python symbols for %s, skipping injection\n",
+			pytrace_proc_str(pid, ns_tid_by_host_tid(pid, pid), proc_name(pid)));
+		return err;
+	}
+
+	snprintf(log_path, sizeof(log_path), LIBWPROFINJ_PYTRACE_LOG_PATH_FMT, getpid(), pid);
+	log_fd = openat(workdir_fd, log_path, O_RDWR | O_CREAT | O_CLOEXEC, 0644);
+	if (log_fd < 0) {
+		err = -errno;
+		eprintf("Failed to create pytrace tracee %s log file at '%s': %d\n",
+			pytrace_proc_str(pid, ns_tid_by_host_tid(pid, pid), proc_name(pid)),
+			log_path, err);
+		return err;
+	}
+
+	vprintf("Injecting libwprofinj.so into %s (Python 3.%d)...\n",
+		pytrace_proc_str(pid, ns_tid_by_host_tid(pid, pid), proc_name(pid)), bi.py_version_minor);
+
+	struct tracee_state *tracee = tracee_inject(pid);
+	if (!tracee) {
+		err = -errno;
+		close(log_fd);
+		eprintf("PTRACE injection failed for %s: %d\n",
+			pytrace_proc_str(pid, ns_tid_by_host_tid(pid, pid), proc_name(pid)), err);
+		return err;
+	}
+
+	vprintf("Injection successful, performing handshake with %s...\n",
+		pytrace_proc_str(pid, ns_tid_by_host_tid(pid, pid), proc_name(pid)));
+
+	err = tracee_handshake(tracee, log_fd, false);
+	if (err) {
+		eprintf("Injection handshake with %s failed: %d\n",
+			pytrace_proc_str(pid, ns_tid_by_host_tid(pid, pid), proc_name(pid)), err);
+		goto err_retract;
+	}
+
+	struct pytrace_tracee *pf = add_pytrace_tracee(tracee);
+
+	pf->log_fd = log_fd;
+	pf->log_path = strdup(log_path);
+	pf->py_version_minor = bi.py_version_minor;
+	memcpy(pf->sym_addrs, sym_addrs, sizeof(sym_addrs));
+	pf->state = TRACEE_INJECTED;
+
+	return 0;
+
+err_retract:
+	close(log_fd);
+	(void)tracee_retract(tracee);
+	tracee_free(tracee);
+	return err;
+}
+
+int pytrace_trace_setup(int workdir_fd)
+{
+	int err = 0;
+
+retry:
+	switch (env.pytrace_discovery) {
+	case PYTRACE_DISCOVER_PROC: {
+		int *pidp, pid;
+
+		wprof_for_each(proc, pidp) {
+			pid = *pidp;
+			try_inject_to_python_process(pid, workdir_fd, false);
+		}
+		break;
+	}
+	case PYTRACE_DISCOVER_NVIDIA_SMI: {
+		vprintf("Using nvidia-smi to find Python processes using GPU...\n");
+
+		FILE *f = popen("nvidia-smi --query-compute-apps=pid --format=csv,noheader", "r");
+		if (!f) {
+			eprintf("Failed to query nvidia-smi, falling back to process discovery logic...\n");
+			env.pytrace_discovery = PYTRACE_DISCOVER_PROC;
+			goto retry;
+		}
+
+		char pidbuf[32];
+		int pid;
+		while (fgets(pidbuf, sizeof(pidbuf), f)) {
+			if (sscanf(pidbuf, "%d", &pid) != 1)
+				continue;
+
+			try_inject_to_python_process(pid, workdir_fd, false);
+		}
+
+		pclose(f);
+		break;
+	}
+	case PYTRACE_DISCOVER_NONE:
+		break;
+	default:
+		eprintf("Unrecognized pytrace discovery strategy %d!\n", env.pytrace_discovery);
+		return -EOPNOTSUPP;
+	}
+
+	/* Also try explicitly specified PIDs */
+	for (int i = 0; i < env.pytrace_pid_cnt; i++) {
+		int pid = env.pytrace_pids[i];
+
+		/* TODO(patlu): refactor -fpy-trace=<PID> to valid no duplication, then we can drop this */
+		bool found = false;
+		for (int j = 0; j < env.pytrace_cnt; j++) {
+			if (env.pytraces[j].pid == pid) {
+				found = true;
+				break;
+			}
+		}
+		if (found)
+			continue;
+
+		try_inject_to_python_process(pid, workdir_fd);
+	}
+
+	return 0;
+}
+
+int pytrace_trace_prepare(int workdir_fd, long sess_timeout_ms)
+{
+	for (int i = 0; i < env.pytrace_cnt; i++) {
+		struct pytrace_tracee *pf = &env.pytraces[i];
+
+		char dump_path[128];
+		snprintf(dump_path, sizeof(dump_path), LIBWPROFINJ_PYTRACE_DUMP_PATH_FMT, getpid(), pf->pid);
+
+		int dump_fd = openat(workdir_fd, dump_path, O_RDWR | O_CREAT | O_CLOEXEC, 0644);
+		if (dump_fd < 0) {
+			int err = -errno;
+			eprintf("Failed to create pytrace tracee %s dump file at '%s': %d\n",
+				pytrace_str(pf), dump_path, err);
+			return err;
+		}
+
+		vprintf("Sending PYTRACE_SESSION to tracee #%d (%s), Python 3.%d, timeout %ldms...\n",
+			i, pytrace_str(pf), pf->py_version_minor, sess_timeout_ms);
+
+		struct inj_msg msg = {
+			.kind = INJ_MSG_PYTRACE_SESSION,
+			.pytrace_session = {
+				.session_timeout_ms = sess_timeout_ms,
+				.py_version_minor = pf->py_version_minor,
+			},
+		};
+		memcpy(msg.pytrace_session.sym_addrs, pf->sym_addrs, sizeof(pf->sym_addrs));
+		int err = uds_send_data(pf->uds_fd, &msg, sizeof(msg), &dump_fd, 1);
+		if (err < 0) {
+			eprintf("Failed to start pytrace trace session for tracee %s: %d\n",
+				pytrace_str(pf), err);
+			close(dump_fd);
+			pf->state = TRACEE_SETUP_FAILED;
+			continue;
+		}
+
+		pf->dump_fd = dump_fd;
+		pf->dump_path = strdup(dump_path);
+		pf->state = TRACEE_PENDING;
+	}
+
+	/* Wait for tracees to be ready */
+	vprintf("Waiting for pytrace tracees to be ready...\n");
+	u64 start_ts = ktime_now_ns();
+	for (int i = 0; i < env.pytrace_cnt; i++) {
+		struct pytrace_tracee *pf = &env.pytraces[i];
+
+		if (pf->state != TRACEE_PENDING)
+			continue;
+
+		while (*(volatile enum inj_setup_state *)&pf->ctx->setup_state == INJ_SETUP_PENDING &&
+		       (ktime_now_ns() - start_ts < LIBWPROFINJ_SETUP_TIMEOUT_MS * 1000000ULL)) {
+			usleep(10000);
+		}
+
+		switch (pf->ctx->setup_state) {
+		case INJ_SETUP_READY:
+			vprintf("pytrace tracee #%d (%s) is READY!\n", i, pytrace_str(pf));
+			pf->state = TRACEE_ACTIVE;
+			break;
+		case INJ_SETUP_FAILED:
+		default:
+			if (pf->ctx->exit_hint) {
+				vprintf("pytrace tracee #%d (%s) failed: '%s'.\n",
+					i, pytrace_str(pf), pf->ctx->exit_hint_msg);
+				pf->state = TRACEE_SETUP_FAILED;
+			} else {
+				vprintf("pytrace tracee #%d (%s) TIMED OUT!\n", i, pytrace_str(pf));
+				pf->state = TRACEE_SETUP_TIMEOUT;
+			}
+			break;
+		}
+	}
+
+	return 0;
+}
+
+int pytrace_trace_activate(long sess_start_ts, long sess_end_ts)
+{
+	for (int i = 0; i < env.pytrace_cnt; i++) {
+		struct pytrace_tracee *pf = &env.pytraces[i];
+
+		if (pf->state != TRACEE_ACTIVE)
+			continue;
+
+		pf->ctx->sess_end_ts = sess_end_ts;
+		pf->ctx->sess_start_ts = sess_start_ts;
+	}
+
+	return 0;
+}
+
+static void dump_tracee_log(struct pytrace_tracee *pf, int idx)
+{
+	if (!(env_log_set & LOG_PYTRACE))
+		return;
+
+	vprintf("PyTrace tracee #%d (%s) LOG (%s) DUMP (LAST STATE %s):\n"
+		"=======================================================================================================\n",
+		idx, pytrace_str(pf), pf->log_path, cuda_tracee_state_str(pf->state));
+
+	lseek(pf->log_fd, 0, SEEK_SET);
+
+	FILE *f = fdopen(pf->log_fd, "r");
+	if (!f) {
+		int err = -errno;
+		eprintf("Failed to create FILE wrapper around pytrace tracee #%d (%s) log FD: %d\n",
+			idx, pytrace_str(pf), err);
+		return;
+	}
+
+	char buf[4096];
+	while (fgets(buf, sizeof(buf), f)) {
+		vprintf("    %s", buf);
+	}
+
+	vprintf("=======================================================================================================\n");
+
+	fclose(f);
+	pf->log_fd = -1;
+}
+
+void pytrace_trace_deactivate(void)
+{
+	if (env.pytraces_deactivated)
+		return;
+
+	wprintf("Deactivating pytrace trace injections...\n");
+
+	for (int i = 0; i < env.pytrace_cnt; i++) {
+		struct pytrace_tracee *pf = &env.pytraces[i];
+
+		if (pf->state == TRACEE_SETUP_FAILED || pf->state == TRACEE_SETUP_TIMEOUT) {
+			zclose(pf->uds_fd);
+			dump_tracee_log(pf, i);
+			continue;
+		}
+
+		vprintf("Signaling pytrace tracee #%d (%s) to exit...\n", i, pytrace_str(pf));
+
+		struct inj_msg msg = {
+			.kind = INJ_MSG_SHUTDOWN,
+			.shutdown = { },
+		};
+		int err = uds_send_data(pf->uds_fd, &msg, sizeof(msg), NULL, 0);
+
+		zclose(pf->uds_fd);
+
+		if (err < 0) {
+			eprintf("Failed to send SHUTDOWN to pytrace tracee #%d (%s): %d\n",
+				i, pytrace_str(pf), err);
+			if (pf->state == TRACEE_ACTIVE)
+				pf->state = TRACEE_SHUTDOWN_FAILED;
+			dump_tracee_log(pf, i);
+			continue;
+		}
+	}
+
+	/* Wait for tracees to shut down */
+	vprintf("Waiting for pytrace tracees to shut down...\n");
+	u64 start_ts = ktime_now_ns();
+	for (int i = 0; i < env.pytrace_cnt; i++) {
+		struct pytrace_tracee *pf = &env.pytraces[i];
+
+		if (pf->state != TRACEE_ACTIVE)
+			continue;
+
+		while (!pf->ctx->worker_thread_done &&
+		       (ktime_now_ns() - start_ts < LIBWPROFINJ_TEARDOWN_TIMEOUT_MS * 1000000ULL)) {
+			usleep(10000);
+		}
+
+		if (!pf->ctx->worker_thread_done) {
+			eprintf("pytrace tracee #%d (%s) TIMED OUT DURING TEARDOWN!\n",
+				i, pytrace_str(pf));
+			pf->state = TRACEE_SHUTDOWN_TIMEOUT;
+		} else {
+			vprintf("pytrace tracee #%d (%s) shut down cleanly"
+				" (%ld events, %ld code objects cached).\n",
+				i, pytrace_str(pf),
+				pf->ctx->pytrace_event_cnt, pf->ctx->pytrace_code_cache_cnt);
+			pf->state = TRACEE_INACTIVE;
+		}
+
+		dump_tracee_log(pf, i);
+	}
+
+	env.pytraces_deactivated = true;
+}
+
+void pytrace_trace_retract(void)
+{
+	if (env.pytraces_retracted)
+		return;
+
+	wprintf("Retracting pytrace trace injections...\n");
+
+	for (int i = 0; i < env.pytrace_cnt; i++) {
+		struct pytrace_tracee *pf = &env.pytraces[i];
+
+		switch (pf->state) {
+		case TRACEE_SETUP_FAILED:
+		case TRACEE_INACTIVE:
+			break;
+		default:
+			continue;
+		}
+
+		dprintf(1, "Retracting pytrace tracee #%d (%s)...\n", i, pytrace_str(pf));
+
+		int err = tracee_retract(pf->tracee);
+		if (err) {
+			eprintf("Retraction for pytrace tracee #%d (%s) FAILED: %d!\n",
+				i, pytrace_str(pf), err);
+		}
+	}
+
+	env.pytraces_retracted = true;
+}
+
+void pytrace_trace_teardown(void)
+{
+	pytrace_trace_deactivate();
+	pytrace_trace_retract();
+
+	for (int i = 0; i < env.pytrace_cnt; i++) {
+		struct pytrace_tracee *pf = &env.pytraces[i];
+
+		zclose(pf->uds_fd);
+		zclose(pf->dump_fd);
+		zclose(pf->log_fd);
+	}
+}

--- a/src/pytrace.c
+++ b/src/pytrace.c
@@ -6,8 +6,6 @@
 #include <stdio.h>
 #include <linux/fs.h>
 #include <fcntl.h>
-#include <sys/stat.h>
-#include <sys/sysmacros.h>
 
 #include "pytrace.h"
 #include "cuda.h"
@@ -17,9 +15,11 @@
 #include "inj_common.h"
 #include "inject.h"
 #include "elf_utils.h"
+#include "pydisc.h"
 
 #define LIBWPROFINJ_PYTRACE_LOG_PATH_FMT "wprofinj-pytrace-log.%d.%d.log"
 #define LIBWPROFINJ_PYTRACE_DUMP_PATH_FMT "wprofinj-pytrace.%d.%d.data"
+#define LIBWPROFINJ_TORCH_DUMP_PATH_FMT "wprofinj-torch.%d.%d.data"
 
 static const char *pytrace_proc_str(int pid, int ns_pid, const char *proc_name)
 {
@@ -57,6 +57,7 @@ static struct pytrace_tracee *add_pytrace_tracee(struct tracee_state *tracee)
 
 	pf->log_fd = -1;
 	pf->dump_fd = -1;
+	pf->torch_dump_fd = -1;
 
 	env.pytrace_cnt++;
 
@@ -107,11 +108,11 @@ static int try_inject_to_python_process(int pid, int workdir_fd)
 	err = py_find_binary(pid, &bi);
 	if (err) {
 		dlogf(PYTRACE, 1, "PID %d (%s) is not Python, skipping\n", pid, proc_name(pid));
-		return -ENOENT;
+		return 0;
 	}
 
-	vprint("Process %s is Python 3.%d!\n",
-	      pytrace_proc_str(pid, ns_tid_by_host_tid(pid, pid), proc_name(pid)), bi.py_version_minor);
+	vprintf("Process %s is Python 3.%d!\n",
+	      pytrace_proc_str(pid, ns_tid_by_host_tid(pid, pid), proc_name(pid)), bi.py_minor);
 
 	dlogf(PYTRACE, 0, "PID %d: Python binary at '%s', base_addr=0x%lx\n", pid, bi.host_path, bi.base_addr);
 
@@ -134,7 +135,7 @@ static int try_inject_to_python_process(int pid, int workdir_fd)
 	}
 
 	vprintf("Injecting libwprofinj.so into %s (Python 3.%d)...\n",
-		pytrace_proc_str(pid, ns_tid_by_host_tid(pid, pid), proc_name(pid)), bi.py_version_minor);
+		pytrace_proc_str(pid, ns_tid_by_host_tid(pid, pid), proc_name(pid)), bi.py_minor);
 
 	struct tracee_state *tracee = tracee_inject(pid);
 	if (!tracee) {
@@ -159,7 +160,7 @@ static int try_inject_to_python_process(int pid, int workdir_fd)
 
 	pf->log_fd = log_fd;
 	pf->log_path = strdup(log_path);
-	pf->py_version_minor = bi.py_version_minor;
+	pf->py_version_minor = bi.py_minor;
 	memcpy(pf->sym_addrs, sym_addrs, sizeof(sym_addrs));
 	pf->state = TRACEE_INJECTED;
 
@@ -174,8 +175,6 @@ err_retract:
 
 int pytrace_trace_setup(int workdir_fd)
 {
-	int err = 0;
-
 retry:
 	switch (env.pytrace_discovery) {
 	case PYTRACE_DISCOVER_PROC: {
@@ -183,7 +182,7 @@ retry:
 
 		wprof_for_each(proc, pidp) {
 			pid = *pidp;
-			try_inject_to_python_process(pid, workdir_fd, false);
+			try_inject_to_python_process(pid, workdir_fd);
 		}
 		break;
 	}
@@ -203,7 +202,7 @@ retry:
 			if (sscanf(pidbuf, "%d", &pid) != 1)
 				continue;
 
-			try_inject_to_python_process(pid, workdir_fd, false);
+			try_inject_to_python_process(pid, workdir_fd);
 		}
 
 		pclose(f);
@@ -256,15 +255,32 @@ int pytrace_trace_prepare(int workdir_fd, long sess_timeout_ms)
 		vprintf("Sending PYTRACE_SESSION to tracee #%d (%s), Python 3.%d, timeout %ldms...\n",
 			i, pytrace_str(pf), pf->py_version_minor, sess_timeout_ms);
 
+		int torch_dump_fd = -1;
+		if (env.capture_pytorch == TRUE) {
+			char torch_path[128];
+			snprintf(torch_path, sizeof(torch_path), LIBWPROFINJ_TORCH_DUMP_PATH_FMT, getpid(), pf->pid);
+			torch_dump_fd = openat(workdir_fd, torch_path, O_RDWR | O_CREAT | O_CLOEXEC, 0644);
+			if (torch_dump_fd < 0) {
+				eprintf("Failed to create torch dump file at '%s': %d (continuing without torch profiling)\n",
+					torch_path, -errno);
+			} else {
+				pf->torch_dump_fd = torch_dump_fd;
+				pf->torch_dump_path = strdup(torch_path);
+			}
+		}
+
 		struct inj_msg msg = {
 			.kind = INJ_MSG_PYTRACE_SESSION,
 			.pytrace_session = {
 				.session_timeout_ms = sess_timeout_ms,
 				.py_version_minor = pf->py_version_minor,
+				.enable_torch_profiler = (torch_dump_fd >= 0),
 			},
 		};
 		memcpy(msg.pytrace_session.sym_addrs, pf->sym_addrs, sizeof(pf->sym_addrs));
-		int err = uds_send_data(pf->uds_fd, &msg, sizeof(msg), &dump_fd, 1);
+		int fds[2] = { dump_fd, torch_dump_fd };
+		int fd_cnt = (torch_dump_fd >= 0) ? 2 : 1;
+		int err = uds_send_data(pf->uds_fd, &msg, sizeof(msg), fds, fd_cnt);
 		if (err < 0) {
 			eprintf("Failed to start pytrace trace session for tracee %s: %d\n",
 				pytrace_str(pf), err);
@@ -467,6 +483,7 @@ void pytrace_trace_teardown(void)
 
 		zclose(pf->uds_fd);
 		zclose(pf->dump_fd);
+		zclose(pf->torch_dump_fd);
 		zclose(pf->log_fd);
 	}
 }

--- a/src/pytrace.h
+++ b/src/pytrace.h
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright (c) 2026 Meta Platforms, Inc. */
+#ifndef __PYTRACE_H_
+#define __PYTRACE_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "cuda.h"
+#include "inj_common.h"
+
+#define DEFAULT_CAPTURE_PYTRACE FALSE
+
+struct tracee_state;
+struct inj_run_ctx;
+
+enum pytrace_discover_strategy {
+	PYTRACE_DISCOVER_NONE,		/* no automatic discovery */
+	PYTRACE_DISCOVER_PROC,		/* find Python processes via /proc scan (default) */
+	PYTRACE_DISCOVER_NVIDIA_SMI,	/* use nvidia-smi to find GPU Python processes */
+};
+
+struct pytrace_tracee {
+	int pid;
+	int ns_pid;
+	const char *proc_name;
+	int uds_fd;
+
+	enum cuda_tracee_state state; /* reuse same state machine as CUDA */
+
+	int log_fd;
+	char *log_path;
+
+	int dump_fd;
+	char *dump_path;
+
+	int py_version_minor;	/* detected Python 3.x version */
+	unsigned long sym_addrs[PYTRACE_SYM_CNT];
+
+	struct tracee_state *tracee;
+	struct inj_run_ctx *ctx;
+};
+
+const char *pytrace_str(const struct pytrace_tracee *t);
+
+int pytrace_trace_setup(int workdir_fd);
+void pytrace_trace_teardown(void);
+int pytrace_trace_prepare(int workdir_fd, long sess_timeout_ms);
+int pytrace_trace_activate(long sess_start_ts, long sess_end_ts);
+void pytrace_trace_deactivate(void);
+void pytrace_trace_retract(void);
+
+#endif /* __PYTRACE_H_ */

--- a/src/pytrace.h
+++ b/src/pytrace.h
@@ -13,12 +13,6 @@
 struct tracee_state;
 struct inj_run_ctx;
 
-enum pytrace_discover_strategy {
-	PYTRACE_DISCOVER_NONE,		/* no automatic discovery */
-	PYTRACE_DISCOVER_PROC,		/* find Python processes via /proc scan (default) */
-	PYTRACE_DISCOVER_NVIDIA_SMI,	/* use nvidia-smi to find GPU Python processes */
-};
-
 struct pytrace_tracee {
 	int pid;
 	int ns_pid;
@@ -32,6 +26,9 @@ struct pytrace_tracee {
 
 	int dump_fd;
 	char *dump_path;
+
+	int torch_dump_fd;
+	char *torch_dump_path;
 
 	int py_version_minor;	/* detected Python 3.x version */
 	unsigned long sym_addrs[PYTRACE_SYM_CNT];

--- a/src/pytrace_data.h
+++ b/src/pytrace_data.h
@@ -1,0 +1,92 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright (c) 2026 Meta Platforms, Inc. */
+#ifndef __PYTRACE_DATA_H_
+#define __PYTRACE_DATA_H_
+
+#include "wprof_types.h"
+
+#define WPYTRACE_DATA_FLAG_INCOMPLETE 0xffffffffffffffffULL
+
+struct wpytrace_data_hdr {
+	char magic[8];
+	u16 hdr_sz;
+	u16 padding;
+	u64 flags;		/* WPYTRACE_DATA_FLAG_INCOMPLETE during recording, cleared on finalization */
+	u64 sess_start_ns;
+	u64 sess_end_ns;
+	u64 events_off;
+	u64 events_sz;
+	u64 event_cnt;
+	u64 strs_off;
+	u64 strs_sz;
+	u64 code_map_off;
+	u64 code_map_sz;
+	u64 code_map_cnt;
+} __attribute__((aligned(8)));
+
+/* Raw event recorded in the hot path */
+struct wpytrace_event {
+	u64 ts;
+	u64 code_key;
+	u32 tid;
+	u8  what;		/* PyTrace_CALL=0, PyTrace_RETURN=3 */
+	u8  pad[3];
+};
+
+/* Code object map entry: maps code_key -> string offsets */
+struct wpytrace_code_entry {
+	u64 code_key;
+	u32 func_name_off;
+	u32 file_name_off;
+	u32 lineno;
+	u32 padding;
+};
+
+static inline const char *wpytrace_str(struct wpytrace_data_hdr *hdr, u32 off)
+{
+	return (void *)hdr + hdr->hdr_sz + hdr->strs_off + off;
+}
+
+/* WPYTRACE_EVENT ITERATOR */
+struct wpytrace_event_record {
+	struct wpytrace_event *e;
+	int idx;
+};
+
+struct wpytrace_event_iter {
+	void *next;
+	void *last;
+	int next_idx;
+	struct wpytrace_event_record rec;
+};
+
+static inline struct wpytrace_event_iter wpytrace_event_iter_new(void *data)
+{
+	struct wpytrace_data_hdr *hdr = data;
+
+	return (struct wpytrace_event_iter) {
+		.next = data + hdr->hdr_sz + hdr->events_off,
+		.last = data + hdr->hdr_sz + hdr->events_off + hdr->events_sz,
+	};
+}
+
+static inline struct wpytrace_event_record *wpytrace_event_iter_next(struct wpytrace_event_iter *it)
+{
+	if (it->next >= it->last)
+		return NULL;
+
+	it->rec.e = it->next;
+	it->rec.idx = it->next_idx;
+
+	it->next += sizeof(struct wpytrace_event);
+	it->next_idx += 1;
+
+	return &it->rec;
+}
+
+#define wpytrace_for_each_event(rec, data) for (						\
+	struct wpytrace_event_iter it = wpytrace_event_iter_new(data);			\
+	(rec = wpytrace_event_iter_next(&it));						\
+)
+
+#endif /* __PYTRACE_DATA_H_ */

--- a/src/pytrace_data.h
+++ b/src/pytrace_data.h
@@ -24,13 +24,19 @@ struct wpytrace_data_hdr {
 	u64 code_map_cnt;
 } __attribute__((aligned(8)));
 
+/* PyTorch RecordFunction what values — start at 20 to leave room for growth */
+#define WPYTRACE_PYTORCH_ENTRY 20
+#define WPYTRACE_PYTORCH_EXIT  21
+
 /* Raw event recorded in the hot path */
 struct wpytrace_event {
 	u64 ts;
 	u64 code_key;
 	u32 tid;
-	u8  what;		/* PyTrace_CALL=0, PyTrace_RETURN=3 */
-	u8  pad[3];
+	u8  what;		/* PyTrace_CALL=0, PyTrace_RETURN=3, WPYTRACE_RF_ENTRY=20, WPYTRACE_RF_EXIT=21 */
+	u8  padding[3];
+	u32 rf_name_off;
+	u32 padding2;
 };
 
 /* Code object map entry: maps code_key -> string offsets */

--- a/src/pytrace_data.h
+++ b/src/pytrace_data.h
@@ -89,4 +89,12 @@ static inline struct wpytrace_event_record *wpytrace_event_iter_next(struct wpyt
 	(rec = wpytrace_event_iter_next(&it));						\
 )
 
+static inline int wpytrace_code_entry_cmp(const void *a, const void *b)
+{
+	const struct wpytrace_code_entry *ea = a, *eb = b;
+	if (ea->code_key < eb->code_key) return -1;
+	if (ea->code_key > eb->code_key) return 1;
+	return 0;
+}
+
 #endif /* __PYTRACE_DATA_H_ */

--- a/src/utils.h
+++ b/src/utils.h
@@ -67,6 +67,7 @@ enum log_subset {
 	LOG_TOPOLOGY = 0x04,
 	LOG_INJECTION = 0x08,
 	LOG_TRACEE = 0x10,
+	LOG_PYTRACE = 0x20,
 };
 
 extern bool env_verbose;

--- a/src/wevent.h
+++ b/src/wevent.h
@@ -207,6 +207,13 @@ struct wevent {
 			u32 event_id;
 			u8 sync_type;
 		} cuda_sync;
+
+		/* Python function tracing events (from PyEval_SetProfile) */
+		struct wevent_pytrace {
+			u32 func_name_stroff;
+			u32 file_name_stroff;
+			u32 lineno;
+		} pytrace;
 	};
 };
 
@@ -242,6 +249,9 @@ static inline size_t wevent_fixed_sz(const struct wevent *e)
 	case EV_CUDA_SYNC:	return WEVENT_SZ(cuda_sync);
 	case EV_CUDA_API:	return WEVENT_SZ(cuda_api);
 
+	case EV_PYTRACE_ENTRY:	return WEVENT_SZ(pytrace);
+	case EV_PYTRACE_EXIT:	return WEVENT_SZ(pytrace);
+
 	case EV_CUDA_CALL:	return 0; /* CUDA_CALL is "merged" into CUDA_API */
 	default:		return 0;
 	}
@@ -273,6 +283,8 @@ static inline const char *wevent_kind_name(enum event_kind kind)
 	case EV_CUDA_MEMSET:	return "cuda_memset";
 	case EV_CUDA_SYNC:	return "cuda_sync";
 	case EV_CUDA_API:	return "cuda_api";
+	case EV_PYTRACE_ENTRY:	return "pytrace_entry";
+	case EV_PYTRACE_EXIT:	return "pytrace_exit";
 	default:		return "unknown";
 	}
 }

--- a/src/wevent.h
+++ b/src/wevent.h
@@ -214,6 +214,11 @@ struct wevent {
 			u32 file_name_stroff;
 			u32 lineno;
 		} pytrace;
+
+		/* PyTorch RecordFunction events (from at::addGlobalCallback) */
+		struct wevent_rf {
+			u32 name_stroff;	/* op name, e.g. "aten::linear" — only set for PYTORCH_ENTRY */
+		} rf;
 	};
 };
 
@@ -252,6 +257,9 @@ static inline size_t wevent_fixed_sz(const struct wevent *e)
 	case EV_PYTRACE_ENTRY:	return WEVENT_SZ(pytrace);
 	case EV_PYTRACE_EXIT:	return WEVENT_SZ(pytrace);
 
+	case EV_PYTORCH_ENTRY:	return WEVENT_SZ(rf);
+	case EV_PYTORCH_EXIT:	return WEVENT_SZ(rf);
+
 	case EV_CUDA_CALL:	return 0; /* CUDA_CALL is "merged" into CUDA_API */
 	default:		return 0;
 	}
@@ -285,6 +293,8 @@ static inline const char *wevent_kind_name(enum event_kind kind)
 	case EV_CUDA_API:	return "cuda_api";
 	case EV_PYTRACE_ENTRY:	return "pytrace_entry";
 	case EV_PYTRACE_EXIT:	return "pytrace_exit";
+	case EV_PYTORCH_ENTRY:	return "pytorch_entry";
+	case EV_PYTORCH_EXIT:	return "pytorch_exit";
 	default:		return "unknown";
 	}
 }

--- a/src/wprof.c
+++ b/src/wprof.c
@@ -45,6 +45,8 @@
 #include "requests.h"
 #include "cuda.h"
 #include "cuda_data.h"
+#include "pytrace.h"
+#include "pytrace_data.h"
 #include "bpf_utils.h"
 #include "sys.h"
 #include "inject.h"
@@ -77,6 +79,10 @@ const struct capture_feature capture_features[] = {
 	 offsetof(struct env, capture_cuda), cfg_get_capture_cuda, cfg_set_capture_cuda},
 	{"Python stacks", "Pystacks:", DEFAULT_CAPTURE_PYSTACKS,
 	 offsetof(struct env, capture_pystacks), cfg_get_capture_pystacks, cfg_set_capture_pystacks},
+	{"Python function tracing", "PyTrace:", DEFAULT_CAPTURE_PYTRACE,
+	 offsetof(struct env, capture_pytrace), cfg_get_capture_pytrace, cfg_set_capture_pytrace},
+	{"PyTorch RecordFunction", "Torch:", DEFAULT_CAPTURE_TORCH_PROFILER,
+	 offsetof(struct env, capture_pytorch), cfg_get_capture_pytorch, cfg_set_capture_pytorch},
 };
 
 const int capture_feature_cnt = ARRAY_SIZE(capture_features);
@@ -525,6 +531,14 @@ static int setup_bpf(struct bpf_state *st, struct worker_state *workers, int num
 		}
 		if (env.requested_stack_traces & ST_CUDA)
 			bpf_program__set_autoload(skel->progs.wprof_cuda_call, true);
+	}
+
+	if (env.pytrace_pid_cnt > 0 || env.pytrace_discovery) {
+		err = pytrace_trace_setup(workdir_fd);
+		if (err) {
+			eprintf("pytrace trace setup failed: %d\n", err);
+			return err;
+		}
 	}
 
 	if (env.capture_scx) {
@@ -1429,6 +1443,16 @@ int main(int argc, char **argv)
 		}
 	}
 
+	if (env.pytrace_cnt > 0) {
+		wprintf("Preparing pytrace tracees...\n");
+		err = pytrace_trace_prepare(workdir_fd,
+					   env.duration_ns / 1000000 + LIBWPROFINJ_SESSION_TIMEOUT_MS);
+		if (err) {
+			eprintf("Failed to prepare pytrace tracing sessions: %d\n", err);
+			goto cleanup;
+		}
+	}
+
 	wprintf("Running...\n");
 
 	env.ktime_start_ns = ktime_now_ns();
@@ -1452,6 +1476,15 @@ int main(int argc, char **argv)
 				eprintf("Failed to attach CUDA tracking USDTs: %d\n", err);
 				return err;
 			}
+		}
+	}
+
+	if (env.pytrace_cnt > 0) {
+		wprintf("Activating pytrace tracees...\n");
+		err = pytrace_trace_activate(env.sess_start_ts, env.sess_end_ts);
+		if (err) {
+			eprintf("Failed to activate pytrace tracing sessions: %d\n", err);
+			goto cleanup;
 		}
 	}
 
@@ -1483,6 +1516,9 @@ int main(int argc, char **argv)
 			cuda_trace_retract();
 	}
 
+	if (env.pytrace_cnt > 0)
+		pytrace_trace_deactivate();
+
 	wprintf("Draining...\n");
 	drain_bpf(&bpf_state, num_cpus);
 
@@ -1501,6 +1537,9 @@ int main(int argc, char **argv)
 		env.capture_cuda = false;
 	}
 
+	if (env.pytrace_cnt == 0)
+		env.capture_pytrace = false;
+
 	err = wprof_merge_data(workdir_name, workers);
 	if (err) {
 		eprintf("Failed to finalize data dump: %d\n", err);
@@ -1512,6 +1551,9 @@ int main(int argc, char **argv)
 	/* we delayed ptrace retraction to symbolize libwprofinj.so stacks */
 	if (env.requested_stack_traces && env.cuda_cnt > 0)
 		cuda_trace_retract();
+
+	if (env.pytrace_cnt > 0)
+		pytrace_trace_retract();
 
 	{
 		fflush(workers[0].dump);
@@ -1587,6 +1629,8 @@ skip_data_collection:
 cleanup:
 	if (env.cuda_cnt > 0)
 		cuda_trace_teardown();
+	if (env.pytrace_cnt > 0)
+		pytrace_trace_teardown();
 	cleanup_workers(workers, worker_cnt);
 	detach_bpf(&bpf_state, num_cpus);
 	drain_bpf(&bpf_state, num_cpus);

--- a/src/wprof.h
+++ b/src/wprof.h
@@ -99,6 +99,10 @@ enum event_kind {
 	EV_PYTRACE_ENTRY = 60,
 	EV_PYTRACE_EXIT = 61,
 
+	/* PyTorch RecordFunction events (from at::addGlobalCallback) */
+	EV_PYTORCH_ENTRY = 62,
+	EV_PYTORCH_EXIT = 63,
+
 	__EV_KIND_MAX,
 };
 

--- a/src/wprof.h
+++ b/src/wprof.h
@@ -95,6 +95,10 @@ enum event_kind {
 	EV_CUDA_SYNC = 53,
 	EV_CUDA_API = 54,
 
+	/* Python function tracing events (from PyEval_SetProfile) */
+	EV_PYTRACE_ENTRY = 60,
+	EV_PYTRACE_EXIT = 61,
+
 	__EV_KIND_MAX,
 };
 

--- a/test/test_pytrace.py
+++ b/test/test_pytrace.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Simple test program for pytrace tracing. Has a known call tree."""
+import time
+import os
+import threading
+
+def inner():
+    total = 0
+    for i in range(100):
+        total += i
+    return total
+
+def middle():
+    result = 0
+    for _ in range(10):
+        result += inner()
+    return result
+
+def outer():
+    for _ in range(5):
+        middle()
+        time.sleep(0.05)
+
+def worker_inner():
+    total = 0
+    for i in range(100):
+        total += i
+    return total
+
+def worker_task(name):
+    while True:
+        for _ in range(10):
+            worker_inner()
+        time.sleep(0.05)
+
+if __name__ == "__main__":
+    for i in range(3):
+        t = threading.Thread(target=worker_task, args=(f"worker-{i}",), daemon=True)
+        t.start()
+    print(f"PID: {os.getpid()}", flush=True)
+    while True:
+        outer()

--- a/test/test_pytrace.sh
+++ b/test/test_pytrace.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Test script for pytrace tracing.
+# Run with: sudo bash test_pytrace.sh
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WPROF="$SCRIPT_DIR/../src/wprof"
+TEST_PY="$SCRIPT_DIR/test_pytrace.py"
+DATA_OUT="/tmp/pytrace_test.data"
+JSON_OUT="/tmp/pytrace_test.json"
+PB_OUT="/tmp/pytrace_test.pb"
+
+PYTHON=python3
+if [ "$(uname -m)" = "aarch64" ]; then
+    PLATFORM_PYTHON=/usr/local/fbcode/platform010-aarch64/bin/python3.12
+else
+    PLATFORM_PYTHON=/usr/local/fbcode/platform010/bin/python3.12
+fi
+for candidate in "$PLATFORM_PYTHON" python3; do
+    if command -v "$candidate" &>/dev/null; then
+        # Check if the binary has Python C API symbols in its symbol table
+        if readelf -s "$(readlink -f "$(command -v "$candidate")")" 2>/dev/null | grep -q 'PyEval_SetProfile'; then
+            PYTHON="$candidate"
+            break
+        fi
+    fi
+done
+echo "Using Python: $PYTHON ($(readlink -f "$(command -v "$PYTHON")"))"
+
+# Start the test Python program in background
+"$PYTHON" "$TEST_PY" &
+PYTRACE_PID=$!
+echo "Started test Python process with PID: $PYTRACE_PID"
+sleep 1
+
+# Step 1: Capture raw data
+echo ""
+echo "=== Step 1: Capturing (2s)... ==="
+"$WPROF" -f py-trace=$PYTRACE_PID -d2000 -vv --log=pytrace --log=tracee --log=inject -D "$DATA_OUT" 2>&1
+
+kill $PYTRACE_PID 2>/dev/null || true
+wait $PYTRACE_PID 2>/dev/null || true
+
+# Step 2: Generate JSON from captured data
+echo ""
+echo "=== Step 2: Generating JSON trace... ==="
+"$WPROF" -R -J "$JSON_OUT" -D "$DATA_OUT" 2>&1
+
+# Step 3: Generate Perfetto trace from same data
+echo ""
+echo "=== Step 3: Generating Perfetto trace... ==="
+"$WPROF" -R -T "$PB_OUT" -D "$DATA_OUT" 2>&1
+
+# Analyze JSON output
+echo ""
+echo "=== JSON header ==="
+head -1 "$JSON_OUT" | python3 -m json.tool
+
+echo ""
+echo "=== pytrace event counts ==="
+grep -c '"t":"pytrace_entry"' "$JSON_OUT" || echo "pytrace_entry: 0"
+grep -c '"t":"pytrace_exit"' "$JSON_OUT" || echo "pytrace_exit: 0"
+
+echo ""
+echo "=== sample pytrace_entry events ==="
+grep '"t":"pytrace_entry"' "$JSON_OUT" | head -5 | python3 -c "
+import sys, json
+for line in sys.stdin:
+    e = json.loads(line)
+    print(f\"  ts={e['ts']:.9f} name={e.get('name','?')} file={e.get('file','?')} lineno={e.get('lineno','?')}\")
+"
+
+echo ""
+echo "=== sample pytrace_exit events ==="
+grep '"t":"pytrace_exit"' "$JSON_OUT" | head -5 | python3 -c "
+import sys, json
+for line in sys.stdin:
+    e = json.loads(line)
+    print(f\"  ts={e['ts']:.9f} name={e.get('name','?')}\")
+"
+
+echo ""
+echo "=== all unique pytrace function names ==="
+grep '"t":"pytrace_entry"' "$JSON_OUT" | python3 -c "
+import sys, json, collections
+names = collections.Counter()
+for line in sys.stdin:
+    e = json.loads(line)
+    names[e.get('name','?')] += 1
+for name, cnt in names.most_common():
+    print(f'  {cnt:6d}  {name}')
+"
+
+echo ""
+echo "=== pytrace events per tid ==="
+grep '"t":"pytrace_entry"' "$JSON_OUT" | python3 -c "
+import sys, json, collections
+tids = collections.Counter()
+for line in sys.stdin:
+    e = json.loads(line)
+    tids[e.get('task', {}).get('tid', '?')] += 1
+for tid, cnt in sorted(tids.items()):
+    print(f'  tid={tid}: {cnt} calls')
+"
+
+echo ""
+echo "Data file:     $DATA_OUT"
+echo "JSON output:   $JSON_OUT"
+echo "Perfetto trace: $PB_OUT"
+echo "Done."


### PR DESCRIPTION
Python supports in-process [profiling and tracing](https://docs.python.org/3/c-api/profiling.html). However, one of the biggest limitations has been that applications need to link python tracing support (e.g. kineto) during compilation of the binary.

Wprof's injection library solves this problem. This PR uses the injection library to install a Python profiler into the interpreter and subscribe callbacks to capture function call / return timing, constructing a precise python function call history. This is distinct from the previous -f py-stacks, which is sampling based mechanism. With `-f py-trace` introduced in this PR, we capture every python functions and construct a full lossless callstacks.

While tracing a PyTorch training application, I noticed the typical `pt_autograd_0` thread had no information coming from the python callback. It turns out autograd executes pure C++ torch autograd engines. PyTorch has a RecordFunction subsystem to subscribe to these callbacks, but like python function tracing, it's in-process only.

We use the same injection trick to invoke `addGlobalCallback` and subscribe to the torch function callbacks. The complexity is that the torch APIs are C++ based, so we need to match the C++ calling ABI to C. Fortunately, the struct layout is a straightforward 1:1 mapping. We build a C struct and pass it by value when calling addGlobalCallback.

During perfetto rendering, we put all PYFUNC events on a separated track (usually in the bottom of the UI) If user specified `-f py-trace-torch -f cuda`, it will render a combine Python + torch profiler + CUDA GPU traces, all from an out-of-process invocation!

Works on x86 and ARM.