### PR TITLE
Resolve pytorch symbol on host for statically linked binary + bugfix

### DIFF
--- a/src/env.c
+++ b/src/env.c
@@ -447,8 +447,8 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 			env.pytrace_discovery = (val == TRUE) ? PYTRACE_DISCOVER_NVIDIA_SMI : PYTRACE_DISCOVER_NONE;
 			env.capture_pytrace = val;
 			env.capture_pytorch = val;
-		} else if (strncasecmp(arg, "py-torch=", 15) == 0) {
-			const char *pf_arg = arg + 15;
+		} else if (strncasecmp(arg, "py-torch=", 9) == 0) {
+			const char *pf_arg = arg + 9;
 			int pid, n;
 
 			if (val == FALSE) {

--- a/src/inj.h
+++ b/src/inj.h
@@ -70,11 +70,20 @@ int init_cupti_activities(void);
 int start_cupti_activities(void);
 void finalize_cupti_activities(void);
 
-int pytrace_session_setup(int dump_fd, int torch_fd, int version_minor,
-			  unsigned long *sym_addrs, unsigned long *torch_sym_addrs);
+struct pytrace_setup_ctx {
+	int dump_fd;
+	int torch_fd;
+	int version_minor;
+	unsigned long *sym_addrs;
+	int sym_addr_cnt;
+	unsigned long *torch_sym_addrs;
+	int torch_sym_addr_cnt;
+};
+
+int pytrace_session_setup(struct pytrace_setup_ctx *ctx);
 int pytrace_session_finalize(void);
 
-int torch_profiler_setup(int dump_fd, unsigned long *sym_addrs);
+int torch_profiler_setup(int dump_fd, unsigned long *sym_addrs, int sym_addr_cnt);
 int torch_profiler_teardown(void);
 
 #endif /* __INJ_H_ */

--- a/src/inj.h
+++ b/src/inj.h
@@ -70,10 +70,11 @@ int init_cupti_activities(void);
 int start_cupti_activities(void);
 void finalize_cupti_activities(void);
 
-int pytrace_session_setup(int dump_fd, int torch_fd, int version_minor, unsigned long *sym_addrs);
+int pytrace_session_setup(int dump_fd, int torch_fd, int version_minor,
+			  unsigned long *sym_addrs, unsigned long *torch_sym_addrs);
 int pytrace_session_finalize(void);
 
-int torch_profiler_setup(int dump_fd);
+int torch_profiler_setup(int dump_fd, unsigned long *sym_addrs);
 int torch_profiler_teardown(void);
 
 #endif /* __INJ_H_ */

--- a/src/inj_common.h
+++ b/src/inj_common.h
@@ -33,6 +33,15 @@ static const char *pytrace_sym_names[PYTRACE_SYM_CNT] = {
 	"PyEval_SetProfileAllThreads",
 };
 
+#define TORCH_SYM_CNT 3		/* must match ARRAY_SIZE(torch_resolve_syms) in inj_torch_profiler.c */
+
+__attribute__((unused))
+static const char *torch_sym_names[TORCH_SYM_CNT] = {
+	"_ZN2at17addGlobalCallbackENS_22RecordFunctionCallbackE",	/* at::addGlobalCallback */
+	"_ZN2at14removeCallbackEm",					/* at::removeCallback */
+	"_ZNK2at14RecordFunction4nameEv",				/* at::RecordFunction::name */
+};
+
 #define LIBWPROFINJ_SETUP_SYM __libwprof_inj_setup
 #define LIBWPROFINJ_VERSION 1
 
@@ -122,6 +131,7 @@ struct inj_msg {
 			int py_version_minor; /* Python 3.x minor version */
 			bool enable_torch_profiler;
 			unsigned long sym_addrs[PYTRACE_SYM_CNT];
+			unsigned long torch_sym_addrs[TORCH_SYM_CNT];
 		} pytrace_session;
 		struct inj_msg_shutdown {
 		} shutdown;

--- a/src/inj_lib.c
+++ b/src/inj_lib.c
@@ -530,8 +530,16 @@ static int handle_msg(struct inj_msg *msg, int *fds, int fd_cnt)
 
 		int dump_fd = fds[0];
 		int torch_fd = (fd_cnt >= 2 && msg->pytrace_session.enable_torch_profiler) ? fds[1] : -1;
-		if ((err = pytrace_session_setup(dump_fd, torch_fd, py_ver_minor,
-					msg->pytrace_session.sym_addrs, msg->pytrace_session.torch_sym_addrs)) < 0) {
+		struct pytrace_setup_ctx ctx = {
+			.dump_fd = dump_fd,
+			.torch_fd = torch_fd,
+			.version_minor = py_ver_minor,
+			.sym_addrs = msg->pytrace_session.sym_addrs,
+			.sym_addr_cnt = ARRAY_SIZE(msg->pytrace_session.sym_addrs),
+			.torch_sym_addrs = msg->pytrace_session.torch_sym_addrs,
+			.torch_sym_addr_cnt = ARRAY_SIZE(msg->pytrace_session.torch_sym_addrs)
+		};
+		if ((err = pytrace_session_setup(&ctx)) < 0) {
 			elog("Failed to setup pytrace session: %d\n", err);
 			return err;
 		}

--- a/src/inj_lib.c
+++ b/src/inj_lib.c
@@ -530,7 +530,8 @@ static int handle_msg(struct inj_msg *msg, int *fds, int fd_cnt)
 
 		int dump_fd = fds[0];
 		int torch_fd = (fd_cnt >= 2 && msg->pytrace_session.enable_torch_profiler) ? fds[1] : -1;
-		if ((err = pytrace_session_setup(dump_fd, torch_fd, py_ver_minor, msg->pytrace_session.sym_addrs)) < 0) {
+		if ((err = pytrace_session_setup(dump_fd, torch_fd, py_ver_minor,
+					msg->pytrace_session.sym_addrs, msg->pytrace_session.torch_sym_addrs)) < 0) {
 			elog("Failed to setup pytrace session: %d\n", err);
 			return err;
 		}

--- a/src/inj_pytrace.c
+++ b/src/inj_pytrace.c
@@ -304,7 +304,8 @@ static int init_wpytrace_data(FILE *dump)
 	return 0;
 }
 
-int pytrace_session_setup(int dump_fd, int torch_fd, int version_minor, unsigned long *sym_addrs)
+int pytrace_session_setup(int dump_fd, int torch_fd, int version_minor,
+			  unsigned long *sym_addrs, unsigned long *torch_sym_addrs)
 {
 	int err = 0;
 
@@ -328,7 +329,7 @@ int pytrace_session_setup(int dump_fd, int torch_fd, int version_minor, unsigned
 	}
 
 	if (torch_fd >= 0) {
-		err = torch_profiler_setup(torch_fd);
+		err = torch_profiler_setup(torch_fd, torch_sym_addrs);
 		if (err) {
 			vlog("Torch profiler setup failed: %d\n", err);
 			return err;

--- a/src/inj_pytrace.c
+++ b/src/inj_pytrace.c
@@ -304,19 +304,23 @@ static int init_wpytrace_data(FILE *dump)
 	return 0;
 }
 
-int pytrace_session_setup(int dump_fd, int torch_fd, int version_minor,
-			  unsigned long *sym_addrs, unsigned long *torch_sym_addrs)
+int pytrace_session_setup(struct pytrace_setup_ctx *ctx)
 {
 	int err = 0;
 
-	py_version_minor = version_minor;
+	py_version_minor = ctx->version_minor;
 	vlog("Setting up pytrace session (Python 3.%d)...\n", py_version_minor);
+
+	if (ctx->sym_addr_cnt != PYTRACE_SYM_CNT) {
+		elog("BUG: pytrace sym_addr_cnt:%d != PYTRACE_SYM_CNT:%d\n", ctx->sym_addr_cnt, PYTRACE_SYM_CNT);
+		return -EINVAL;
+	}
 
 	/* Assign Python C API function pointers from host-resolved addresses */
 	for (int i = 0; i < PYTRACE_SYM_CNT; i++) {
-		*(void **)pytrace_resolve_syms[i] = (void *)sym_addrs[i];
-		if (sym_addrs[i])
-			vlog("  %s = %p\n", pytrace_sym_names[i], (void *)sym_addrs[i]);
+		*(void **)pytrace_resolve_syms[i] = (void *)ctx->sym_addrs[i];
+		if (ctx->sym_addrs[i])
+			vlog("  %s = %p\n", pytrace_sym_names[i], (void *)ctx->sym_addrs[i]);
 	}
 
 	/*
@@ -328,8 +332,8 @@ int pytrace_session_setup(int dump_fd, int torch_fd, int version_minor,
 		return -ENOENT;
 	}
 
-	if (torch_fd >= 0) {
-		err = torch_profiler_setup(torch_fd, torch_sym_addrs);
+	if (ctx->torch_fd >= 0) {
+		err = torch_profiler_setup(ctx->torch_fd, ctx->torch_sym_addrs, ctx->torch_sym_addr_cnt);
 		if (err) {
 			vlog("Torch profiler setup failed: %d\n", err);
 			return err;
@@ -343,10 +347,10 @@ int pytrace_session_setup(int dump_fd, int torch_fd, int version_minor,
 		return -ENOMEM;
 	}
 
-	pytrace_dump = fdopen(dump_fd, "w");
+	pytrace_dump = fdopen(ctx->dump_fd, "w");
 	if (!pytrace_dump) {
 		err = -errno;
-		elog("Failed to create FILE wrapper around pytrace dump FD %d: %d\n", dump_fd, err);
+		elog("Failed to create FILE wrapper around pytrace dump FD %d: %d\n", ctx->dump_fd, err);
 		goto cleanup;
 	}
 	setvbuf(pytrace_dump, NULL, _IOFBF, PYTRACE_DUMP_BUF_SZ);
@@ -420,7 +424,7 @@ cleanup:
 		fclose(pytrace_dump);
 		pytrace_dump = NULL;
 	} else {
-		zclose(dump_fd);
+		zclose(ctx->dump_fd);
 	}
 	return err;
 }

--- a/src/inj_torch_profiler.c
+++ b/src/inj_torch_profiler.c
@@ -35,18 +35,32 @@ static u64 torch_event_cnt;
 static bool torch_active;
 static pthread_mutex_t torch_lock;
 
-/* RecordFunction C++ API — resolved via dlsym with mangled names */
-static const char *(*rf_name)(const void *record_fn);
-static void (*rf_remove_callback)(u64 handle);
+/* We define a wrapper struct that exactly matches the C++ layout */
+struct rf_callback_struct {
+	void *start;        /* 0  */
+	void *end;          /* 8  */
+	double prob;        /* 16 */
+	bool scopes[10];    /* 24 */
+	bool needs_inputs;  /* 34 */
+	bool needs_outputs; /* 35 */
+	bool needs_ids;     /* 36 */
+	u8 pad[3];          /* 37-39 */
+} __attribute__((packed));
 
+_Static_assert(sizeof(struct rf_callback_struct) == 40,
+	       "rf_callback_struct must be 40 bytes");
 /*
  * addGlobalCallback takes a 40-byte RecordFunctionCallback struct by value.
  * On x86_64, structs >16 bytes are passed on the stack. On aarch64, they're
  * passed by indirect reference (pointer in x0). In both cases the C compiler
  * generates the correct calling convention automatically when we call through
  * a function pointer typed to take the struct by value.
+ *
+ * RecordFunction C++ APIs — resolved before inject
  */
-static void *rf_add_global_callback_ptr;
+static u64 (*rf_add_global_callback)(struct rf_callback_struct cb);
+static const char *(*rf_name)(const void *record_fn);
+static void (*rf_remove_callback)(u64 handle);
 
 static u64 rf_callback_handle;
 static bool rf_active;
@@ -100,7 +114,7 @@ static void *rf_start_cb(void *ret_slot, const void *record_fn)
 
 	u64 ts = ktime_now_ns();
 	u32 tid = (u32)syscall(SYS_gettid);
-	const char *name = rf_name ? rf_name(record_fn) : "?";
+	const char *name = rf_name(record_fn);
 
 	pthread_mutex_lock(&torch_lock);
 	u32 name_off = strset__add_str(torch_dump_strs, name);
@@ -148,38 +162,6 @@ static void rf_end_cb(const void *record_fn, void *ctx)
 		atomic_add(&torch_event_cnt, 1);
 }
 
-/*
- * Call addGlobalCallback with a 40-byte struct passed by value.
- *
- * The C compiler handles the platform-specific calling convention for passing
- * a 40-byte struct by value (stack on x86_64, indirect reference on aarch64).
- * We cast the resolved symbol to a function pointer typed to take the struct
- * by value, and the compiler does the rest.
- */
-
-/* We define a wrapper struct that exactly matches the C++ layout */
-struct rf_callback_struct {
-	void *start;        /* 0  */
-	void *end;          /* 8  */
-	double prob;        /* 16 */
-	bool scopes[10];    /* 24 */
-	bool needs_inputs;  /* 34 */
-	bool needs_outputs; /* 35 */
-	bool needs_ids;     /* 36 */
-	u8 pad[3];          /* 37-39 */
-} __attribute__((packed));
-
-_Static_assert(sizeof(struct rf_callback_struct) == 40,
-	       "rf_callback_struct must be 40 bytes");
-
-typedef u64 (*rf_add_cb_fn_t)(struct rf_callback_struct cb);
-
-static u64 rf_call_add_global_callback(const struct rf_callback_struct *cb)
-{
-	rf_add_cb_fn_t fn = (rf_add_cb_fn_t)rf_add_global_callback_ptr;
-	return fn(*cb);
-}
-
 /* RecordScope enum values from ATen/record_function.h */
 #define RF_SCOPE_FUNCTION          0
 #define RF_SCOPE_BACKWARD_FUNCTION 1
@@ -195,7 +177,7 @@ static void rf_register(void)
 		.scopes = { [RF_SCOPE_FUNCTION] = true, [RF_SCOPE_BACKWARD_FUNCTION] = true, [RF_SCOPE_USER_SCOPE] = true },
 	};
 
-	rf_callback_handle = rf_call_add_global_callback(&cb);
+	rf_callback_handle = rf_add_global_callback(cb);
 	rf_active = true;
 
 	vlog("RecordFunction callback registered (handle=%llu)\n", (unsigned long long)rf_callback_handle);
@@ -206,11 +188,8 @@ static void rf_unregister(void)
 	if (!rf_active)
 		return;
 
-	if (rf_remove_callback) {
-		rf_remove_callback(rf_callback_handle);
-		vlog("RecordFunction callback unregistered (handle=%llu)\n",
-		     (unsigned long long)rf_callback_handle);
-	}
+	rf_remove_callback(rf_callback_handle);
+	vlog("RecordFunction callback unregistered (handle=%llu)\n", (unsigned long long)rf_callback_handle);
 
 	rf_active = false;
 }
@@ -235,7 +214,7 @@ static int verify_mutex_symbols(void)
 
 /* Table of function pointers assigned from host-resolved addresses, must match torch_sym_names order */
 static void **torch_resolve_syms[TORCH_SYM_CNT] = {
-	&rf_add_global_callback_ptr,
+	(void **)&rf_add_global_callback,
 	(void **)&rf_remove_callback,
 	(void **)&rf_name,
 };
@@ -277,18 +256,23 @@ static int init_torch_data(FILE *dump)
 
 /* ==================== Public API ==================== */
 
-int torch_profiler_setup(int dump_fd, unsigned long *sym_addrs)
+int torch_profiler_setup(int dump_fd, unsigned long *sym_addrs, int sym_addr_cnt)
 {
 	int err = 0;
 
+	if (sym_addr_cnt != TORCH_SYM_CNT) {
+		elog("BUG: pytorch torch_sym_addr_cnt:%d != TORCH_SYM_CNT:%d\n", sym_addr_cnt, TORCH_SYM_CNT);
+		return -EINVAL;
+	}
+
 	/* Assign RecordFunction API pointers from host-resolved addresses */
-	for (int i = 0; i < TORCH_SYM_CNT; i++) {
+	for (int i = 0; i < sym_addr_cnt; i++) {
 		*torch_resolve_syms[i] = (void *)sym_addrs[i];
 		if (sym_addrs[i])
 			vlog("  %s = %p\n", torch_sym_names[i], (void *)sym_addrs[i]);
 	}
 
-	if (!rf_add_global_callback_ptr || !rf_remove_callback || !rf_name) {
+	if (!rf_add_global_callback || !rf_remove_callback || !rf_name) {
 		elog("Missing required torch RecordFunction symbols\n");
 		return -ENOENT;
 	}

--- a/src/inj_torch_profiler.c
+++ b/src/inj_torch_profiler.c
@@ -233,37 +233,12 @@ static int verify_mutex_symbols(void)
 	return 0;
 }
 
-static int rf_resolve_symbols(void)
-{
-	/*
-	 * libtorch_cpu.so is loaded by Python's import machinery with RTLD_LOCAL,
-	 * so its C++ symbols aren't visible via RTLD_DEFAULT. We need to get a
-	 * handle to the already-loaded library using RTLD_NOLOAD.
-	 */
-	void *torch_handle = dlopen("libtorch_cpu.so", RTLD_NOLOAD | RTLD_LAZY);
-	if (!torch_handle) {
-		vlog("dlopen(libtorch_cpu.so, NOLOAD) failed: %s\n", dlerror());
-		return -ENOENT;
-	}
-
-	vlog("Got handle to libtorch_cpu.so at %p\n", torch_handle);
-
-	rf_add_global_callback_ptr = dlsym(torch_handle,
-		"_ZN2at17addGlobalCallbackENS_22RecordFunctionCallbackE");
-	rf_remove_callback = dlsym(torch_handle, "_ZN2at14removeCallbackEm");
-	rf_name = dlsym(torch_handle, "_ZNK2at14RecordFunction4nameEv");
-
-	if (rf_add_global_callback_ptr)
-		vlog("Resolved at::addGlobalCallback at %p\n", rf_add_global_callback_ptr);
-	if (rf_remove_callback)
-		vlog("Resolved at::removeCallback at %p\n", (void *)rf_remove_callback);
-	if (rf_name)
-		vlog("Resolved at::RecordFunction::name at %p\n", (void *)rf_name);
-
-	dlclose(torch_handle);
-
-	return rf_add_global_callback_ptr && rf_remove_callback && rf_name ? 0 : -ENOENT;
-}
+/* Table of function pointers assigned from host-resolved addresses, must match torch_sym_names order */
+static void **torch_resolve_syms[TORCH_SYM_CNT] = {
+	&rf_add_global_callback_ptr,
+	(void **)&rf_remove_callback,
+	(void **)&rf_name,
+};
 
 /* ==================== Dump file management ==================== */
 
@@ -302,9 +277,21 @@ static int init_torch_data(FILE *dump)
 
 /* ==================== Public API ==================== */
 
-int torch_profiler_setup(int dump_fd)
+int torch_profiler_setup(int dump_fd, unsigned long *sym_addrs)
 {
 	int err = 0;
+
+	/* Assign RecordFunction API pointers from host-resolved addresses */
+	for (int i = 0; i < TORCH_SYM_CNT; i++) {
+		*torch_resolve_syms[i] = (void *)sym_addrs[i];
+		if (sym_addrs[i])
+			vlog("  %s = %p\n", torch_sym_names[i], (void *)sym_addrs[i]);
+	}
+
+	if (!rf_add_global_callback_ptr || !rf_remove_callback || !rf_name) {
+		elog("Missing required torch RecordFunction symbols\n");
+		return -ENOENT;
+	}
 
 	torch_dump_strs = strset__new(TORCH_DUMP_MAX_STRS_SZ, "", 1);
 	if (!torch_dump_strs) {
@@ -322,11 +309,6 @@ int torch_profiler_setup(int dump_fd)
 
 	if ((err = init_torch_data(torch_dump)) < 0) {
 		elog("Failed to init torch dump: %d\n", err);
-		goto cleanup;
-	}
-
-	if ((err = rf_resolve_symbols()) < 0) {
-		elog("Failed to resolve PyTorch record function symbols");
 		goto cleanup;
 	}
 

--- a/src/merge.c
+++ b/src/merge.c
@@ -500,7 +500,7 @@ int wprof_merge_data(const char *workdir_name, struct worker_state *workers)
 			struct pytrace_tracee *pf = &env.pytraces[wpf->tracee_idx];
 
 			wevent_sz = persist_pytrace_event(&ps, r, &wevent_buf, wpf->dump_hdr,
-							 pf->pid, pf->proc_name,
+							 pf->pid, pf->ns_pid, pf->proc_name,
 							 wpf->code_map, wpf->code_map_cnt,
 							 wpf->strs);
 			if (wevent_sz < 0) {

--- a/src/persist.c
+++ b/src/persist.c
@@ -539,12 +539,12 @@ static const struct wpytrace_code_entry *lookup_pytrace_code(const struct wpytra
 }
 
 int persist_pytrace_event(struct persist_state *ps, const struct wpytrace_event *e, struct wevent *dst,
-			 const struct wpytrace_data_hdr *hdr, int host_pid, const char *proc_name,
+			 const struct wpytrace_data_hdr *hdr, int host_pid, int ns_pid, const char *proc_name,
 			 const struct wpytrace_code_entry *code_map, u64 code_map_cnt,
 			 const char *pytrace_strs)
 {
-	/* Resolve TID -- pytrace events use host-level TIDs directly */
-	struct tid_cache_value *ti = resolve_cuda_host_tid(ps, host_pid, proc_name, host_pid, e->tid);
+	/* Resolve TID -- pytrace TIDs come from gettid() inside tracee and may be namespaced */
+	struct tid_cache_value *ti = resolve_cuda_host_tid(ps, host_pid, proc_name, ns_pid, e->tid);
 	if (!ti)
 		return 0;
 

--- a/src/persist.h
+++ b/src/persist.h
@@ -47,7 +47,7 @@ int persist_bpf_event(struct persist_state *ps, const struct wprof_event *e, str
 int persist_cuda_event(struct persist_state *ps, const struct wcuda_event *e, struct wevent *dst,
 		       int host_pid, const char *proc_name, const char *cuda_strs);
 int persist_pytrace_event(struct persist_state *ps, const struct wpytrace_event *e, struct wevent *dst,
-			 const struct wpytrace_data_hdr *hdr, int host_pid, const char *proc_name,
+			 const struct wpytrace_data_hdr *hdr, int host_pid, int ns_pid, const char *proc_name,
 			 const struct wpytrace_code_entry *code_map, u64 code_map_cnt,
 			 const char *pytrace_strs);
 

--- a/src/pytrace.c
+++ b/src/pytrace.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <sys/sysmacros.h>
 #include <linux/fs.h>
 #include <fcntl.h>
 
@@ -98,10 +99,54 @@ static int pytrace_resolve_symbols(int pid, struct py_binary_info *bi, unsigned 
 	return 0;
 }
 
+/*
+ * Iterate over tracee's VMA mappings to resolve PyTorch RecordFunction symbols
+ * via ELF parsing. Works for both dynamically and statically linked PyTorch.
+ */
+static int torch_resolve_symbols(int pid, unsigned long *sym_addrs)
+{
+	struct vma_info *vma;
+	char host_path[PATH_MAX];
+	unsigned long offsets[TORCH_SYM_CNT] = {};
+	unsigned long base_addr = 0;
+	__u64 last_dev = 0;
+	__u64 last_inode = 0;
+
+	wprof_for_each(vma, vma, pid, VMA_QUERY_FILE_BACKED_VMA) {
+		if (vma->vma_flags & PROCMAP_QUERY_VMA_SHARED)
+			continue;
+		if (vma->vma_name[0] != '/')
+			continue;
+
+		__u64 curr_dev = makedev(vma->dev_major, vma->dev_minor);
+
+		if (vma->inode == last_inode && curr_dev == last_dev)
+			continue;
+
+		last_inode = vma->inode;
+		last_dev = curr_dev;
+
+		snprintf(host_path, sizeof(host_path), "/proc/%d/map_files/%llx-%llx",
+			 pid, (unsigned long long)vma->vma_start, (unsigned long long)vma->vma_end);
+		base_addr = vma->vma_start - vma->vma_offset;
+		if (elf_find_syms(host_path, STT_FUNC, torch_sym_names, offsets, TORCH_SYM_CNT) == 0) {
+			for (int i = 0; i < TORCH_SYM_CNT; i++) {
+				sym_addrs[i] = base_addr + offsets[i];
+				dlogf(PYTRACE, 1, "  %s: offset=0x%lx addr=0x%lx\n", torch_sym_names[i], offsets[i], sym_addrs[i]);
+			}
+			return 0;
+		}
+	}
+
+	eprintf("Failed to resolve torch symbol for PID: %d\n", pid);
+	return -ENOENT;
+}
+
 static int try_inject_to_python_process(int pid, int workdir_fd)
 {
 	struct py_binary_info bi;
 	unsigned long sym_addrs[PYTRACE_SYM_CNT] = {};
+	unsigned long torch_sym_addrs[TORCH_SYM_CNT] = {};
 	char log_path[128];
 	int err = 0, log_fd = -1;
 
@@ -122,6 +167,16 @@ static int try_inject_to_python_process(int pid, int workdir_fd)
 		eprintf("Failed to resolve Python symbols for %s, skipping injection\n",
 			pytrace_proc_str(pid, ns_tid_by_host_tid(pid, pid), proc_name(pid)));
 		return err;
+	}
+
+	/* Resolve PyTorch RecordFunction symbols if torch profiling is requested */
+	if (env.capture_pytorch == TRUE) {
+		err = torch_resolve_symbols(pid, torch_sym_addrs);
+		if (err) {
+			eprintf("Failed to resolve PyTorch symbols for %s, skipping injection\n",
+					pytrace_proc_str(pid, ns_tid_by_host_tid(pid, pid), proc_name(pid)));
+			return err;
+		}
 	}
 
 	snprintf(log_path, sizeof(log_path), LIBWPROFINJ_PYTRACE_LOG_PATH_FMT, getpid(), pid);
@@ -162,6 +217,7 @@ static int try_inject_to_python_process(int pid, int workdir_fd)
 	pf->log_path = strdup(log_path);
 	pf->py_version_minor = bi.py_minor;
 	memcpy(pf->sym_addrs, sym_addrs, sizeof(sym_addrs));
+	memcpy(pf->torch_sym_addrs, torch_sym_addrs, sizeof(torch_sym_addrs));
 	pf->state = TRACEE_INJECTED;
 
 	return 0;
@@ -281,6 +337,7 @@ int pytrace_trace_prepare(int workdir_fd, long sess_timeout_ms)
 			},
 		};
 		memcpy(msg.pytrace_session.sym_addrs, pf->sym_addrs, sizeof(pf->sym_addrs));
+		memcpy(msg.pytrace_session.torch_sym_addrs, pf->torch_sym_addrs, sizeof(pf->torch_sym_addrs));
 		int fds[2] = { dump_fd, torch_dump_fd };
 		int fd_cnt = (torch_dump_fd >= 0) ? 2 : 1;
 		int err = uds_send_data(pf->uds_fd, &msg, sizeof(msg), fds, fd_cnt);

--- a/src/pytrace.c
+++ b/src/pytrace.c
@@ -162,7 +162,9 @@ static int try_inject_to_python_process(int pid, int workdir_fd)
 	dlogf(PYTRACE, 0, "PID %d: Python binary at '%s', base_addr=0x%lx\n", pid, bi.host_path, bi.base_addr);
 
 	/* Resolve all required Python C API symbols before injection */
+	u64 ts = ktime_now_ns();
 	err = pytrace_resolve_symbols(pid, &bi, sym_addrs);
+	dlogf(PYTRACE, 1, "PID %d: pytrace symbol resolution took %.3lfms\n", pid, (ktime_now_ns() - ts) / 1e6);
 	if (err) {
 		eprintf("Failed to resolve Python symbols for %s, skipping injection\n",
 			pytrace_proc_str(pid, ns_tid_by_host_tid(pid, pid), proc_name(pid)));
@@ -171,7 +173,9 @@ static int try_inject_to_python_process(int pid, int workdir_fd)
 
 	/* Resolve PyTorch RecordFunction symbols if torch profiling is requested */
 	if (env.capture_pytorch == TRUE) {
+		ts = ktime_now_ns();
 		err = torch_resolve_symbols(pid, torch_sym_addrs);
+		dlogf(PYTRACE, 1, "PID %d: torch symbol resolution took %.3lfms\n", pid, (ktime_now_ns() - ts) / 1e6);
 		if (err) {
 			eprintf("Failed to resolve PyTorch symbols for %s, skipping injection\n",
 					pytrace_proc_str(pid, ns_tid_by_host_tid(pid, pid), proc_name(pid)));

--- a/src/pytrace.h
+++ b/src/pytrace.h
@@ -32,6 +32,7 @@ struct pytrace_tracee {
 
 	int py_version_minor;	/* detected Python 3.x version */
 	unsigned long sym_addrs[PYTRACE_SYM_CNT];
+	unsigned long torch_sym_addrs[TORCH_SYM_CNT];
 
 	struct tracee_state *tracee;
 	struct inj_run_ctx *ctx;


### PR DESCRIPTION
* There are cases where the PyTorch symbol is not in .so, so we have to move symbol resolution to the host side.
* fixed a few more bugs related to -f py-torch=<PID> parsing.
* Report the symbol resolution timing.