### PR TITLE
elf_utils: fix elf_find_syms() logic and clarify the semantics

### DIFF
--- a/src/elf_utils.c
+++ b/src/elf_utils.c
@@ -221,8 +221,16 @@ int elf_read_sym_value(const char *binary_path, const char *sym_name,
 	return -ENOENT;
 }
 
+/*
+ * Find virtual address offsets relative to binary's base load address for given ELF symbols.
+ *
+ * For shared libs and PIE executables (ET_DYN) this will be just straight st_value,
+ * but for normal executables (ET_EXEC), we'll subtract base load address from st_value.
+ * This allows caller to calculate absolute symbol addresses by adding base load address without
+ * having to take into account whether the binary is position independent or not.
+ */
 int elf_find_syms(const char *binary_path, int st_type,
-		  const char **syms, long *addrs, size_t cnt)
+		  const char **syms, unsigned long *offs, size_t cnt)
 {
 	int sh_types[2] = { SHT_DYNSYM, SHT_SYMTAB };
 	int cnt_done = 0;
@@ -233,42 +241,54 @@ int elf_find_syms(const char *binary_path, int st_type,
 	if (err)
 		return err;
 
-	memset(addrs, 0, sizeof(*addrs) * cnt);
+	memset(offs, 0, sizeof(*offs) * cnt);
 
-	/* Find the ELF base virtual address (first PT_LOAD p_vaddr - p_offset).
-	 * For ET_DYN (shared libs / PIE), symbol st_value includes this base.
-	 * Subtracting it gives the offset from the load bias, so
-	 * (vma_start - vma_offset) + offset = correct runtime address. */
-	unsigned long elf_base_vaddr = 0;
+	/*
+	 * All PT_LOAD segments in ELF should (according to ELF spec) have the same
+	 * (p_vaddr - p_offset) difference, which gives us virtual address base address.
+	 *
+	 * For shared libs and PIE executables that difference has to be zero, so we can skip this
+	 * step, but we currently don't for consistency. It's a fast step.
+	 *
+	 * We later will subtract this base address to give pure offsets as an output.
+	 */
+	unsigned long base_vaddr = 0;
 	GElf_Ehdr ehdr;
 	size_t phnum;
-	if (!gelf_getehdr(elf_fd.elf, &ehdr) || ehdr.e_type != ET_DYN || elf_getphdrnum(elf_fd.elf, &phnum) != 0)
-		goto find;
+	if (!gelf_getehdr(elf_fd.elf, &ehdr) || elf_getphdrnum(elf_fd.elf, &phnum) != 0)
+		return -EINVAL; /* invalid ELF */
+
 	for (size_t i = 0; i < phnum; i++) {
 		GElf_Phdr phdr;
-		if (gelf_getphdr(elf_fd.elf, i, &phdr) && phdr.p_type == PT_LOAD) {
-			elf_base_vaddr = phdr.p_vaddr - phdr.p_offset;
-			break;
-		}
-	}
+		if (!gelf_getphdr(elf_fd.elf, i, &phdr))
+			return -EINVAL; /* invalid ELF */
+		if (phdr.p_type != PT_LOAD)
+			continue;
 
-find:
+		base_vaddr = phdr.p_vaddr - phdr.p_offset;
+		break;
+	}
 
 	for (int ti = 0; ti < ARRAY_SIZE(sh_types) && cnt_done < cnt; ti++) {
 		struct elf_sym *sym;
 
 		wprof_for_each(elf_sym, sym, elf_fd.elf, binary_path, sh_types[ti], st_type) {
 			int bind = GELF_ST_BIND(sym->sym.st_info);
-			unsigned long addr = sym->sym.st_value - elf_base_vaddr;
+			unsigned long off = sym->sym.st_value;
 
+			/*
+			 * We initially store st_value into offs array as is to avoid
+			 * complications of having a valid zero offset interacting unexpectedly
+			 * with STB_WEAK logic below. We'll subtract base_vaddr before returning.
+			 */
 			for (int i = 0; i < cnt; i++) {
 				if (strcmp(syms[i], sym->name) != 0)
 					continue;
-				if (addrs[i] && bind == STB_WEAK)
+				if (offs[i] && bind == STB_WEAK)
 					continue;
-				if (addrs[i] == 0)
+				if (offs[i] == 0)
 					cnt_done++;
-				addrs[i] = addr;
+				offs[i] = off;
 				break;
 			}
 
@@ -278,6 +298,12 @@ find:
 	}
 
 	elf_close(&elf_fd);
+
+	for (int i = 0; i < cnt; i++) {
+		if (offs[i] != 0)
+			offs[i] -= base_vaddr;
+	}
+
 	return cnt_done == cnt ? 0 : -ENOENT;
 }
 

--- a/src/elf_utils.h
+++ b/src/elf_utils.h
@@ -45,6 +45,6 @@ int elf_read_sym_value(const char *binary_path, const char *sym_name,
 		       int st_type, void *buf, size_t buf_sz);
 
 int elf_find_syms(const char *binary_path, int st_type,
-		  const char **syms, long *addrs, size_t cnt);
+		  const char **syms, unsigned long *addrs, size_t cnt);
 
 #endif /* __ELF_UTILS_H__ */

--- a/src/inject.c
+++ b/src/inject.c
@@ -769,15 +769,15 @@ struct tracee_state *tracee_inject(int pid)
 	char lib_path[128];
 	snprintf(lib_path, sizeof(lib_path), "/proc/%d/map_files/%lx-%lx", pid, libc_start, libc_end);
 	const char *sym_names[] = {"dlopen", "dlclose", "dlsym"};
-	long sym_addrs[] = {0, 0, 0};
-	err = elf_find_syms(lib_path, STT_FUNC, sym_names, sym_addrs, ARRAY_SIZE(sym_names));
+	unsigned long sym_offs[] = {0, 0, 0};
+	err = elf_find_syms(lib_path, STT_FUNC, sym_names, sym_offs, ARRAY_SIZE(sym_names));
 	if (err) {
 		elog("Failed to find dlopen/dlclose/dlsym symbols: %d\n", err);
 		goto cleanup;
 	}
-	long dlopen_tracee_off = sym_addrs[0];
-	long dlclose_tracee_off = sym_addrs[1];
-	long dlsym_tracee_off = sym_addrs[2];
+	unsigned long dlopen_tracee_off = sym_offs[0];
+	unsigned long dlclose_tracee_off = sym_offs[1];
+	unsigned long dlsym_tracee_off = sym_offs[2];
 
 	tracee->dlopen_addr = libc_start - libc_fileoff + dlopen_tracee_off;
 	tracee->dlclose_addr = libc_start - libc_fileoff + dlclose_tracee_off;

--- a/src/pydisc.c
+++ b/src/pydisc.c
@@ -80,9 +80,9 @@ static bool is_py_tracee(int pid)
 static bool has_pyruntime_sym(const char *binary_path)
 {
 	const char *syms[] = { "_PyRuntime" };
-	long addrs[1] = { 0 };
+	unsigned long offs[1] = {};
 
-	return elf_find_syms(binary_path, STT_OBJECT, syms, addrs, 1) == 0;
+	return elf_find_syms(binary_path, STT_OBJECT, syms, offs, ARRAY_SIZE(offs)) == 0;
 }
 
 /*
@@ -105,7 +105,7 @@ int py_find_binary(int pid, struct py_binary_info *bi)
 	snprintf(exe_path, sizeof(exe_path), "/proc/%d/exe", pid);
 
 	if (stat(exe_path, &st)) {
-		eprintf("Railed to retrive file status for %s\n", exe_path);
+		eprintf("Failed to retrive file status for %s\n", exe_path);
 		return -errno;
 	}
 	/* Scan static executable or libpython*.so for Py_Version (or _PyRuntime for 3.10).
@@ -159,17 +159,17 @@ static int setup_pid(int pid, const char *binary_path, unsigned long base_addr,
 
 	/* resolve _PyRuntime address */
 	const char *syms[] = { "_PyRuntime" };
-	long addrs[1] = { 0 };
-	err = elf_find_syms(binary_path, STT_OBJECT, syms, addrs, 1);
+	unsigned long offs[1] = {};
+	err = elf_find_syms(binary_path, STT_OBJECT, syms, offs, ARRAY_SIZE(offs));
 	if (err) {
 		eprintf("Failed to find _PyRuntime symbol in '%s' for PID %d: %d\n", binary_path, pid, err);
 		return err;
 	}
 
-	unsigned long py_runtime_addr = base_addr + (unsigned long)addrs[0];
+	unsigned long py_runtime_addr = base_addr + offs[0];
 
 	vprintf("PID %d: _PyRuntime ELF sym=0x%lx base=0x%lx runtime_addr=0x%lx\n",
-		pid, (unsigned long)addrs[0], base_addr, py_runtime_addr);
+		pid, offs[0], base_addr, py_runtime_addr);
 
 	pid_data.py_runtime_addr = py_runtime_addr;
 	pid_data.tls_key_addr = py_runtime_addr + pid_data.offsets.TLSKey_offset;

--- a/src/pytrace.c
+++ b/src/pytrace.c
@@ -71,10 +71,10 @@ static struct pytrace_tracee *add_pytrace_tracee(struct tracee_state *tracee)
  */
 static int pytrace_resolve_symbols(int pid, struct py_binary_info *bi, unsigned long *sym_addrs)
 {
-	long offsets[PYTRACE_SYM_CNT] = {};
+	unsigned long offsets[PYTRACE_SYM_CNT] = {};
 	int err;
 
-	err = elf_find_syms(bi->host_path, STT_FUNC, pytrace_sym_names, offsets, PYTRACE_SYM_CNT);
+	err = elf_find_syms(bi->host_path, STT_FUNC, pytrace_sym_names, offsets, ARRAY_SIZE(offsets));
 	if (err) {
 		for (int i = 0; i < PYTRACE_SYM_CNT; i++) {
 			if (offsets[i])


### PR DESCRIPTION
Make it very explicit that elf_find_syms() returns offsets relative to base load address, regardless of the type of binary.

Suggested-by: Patrick Lu <perf.patrick.lu@gmail.com>
Reported-by: Patrick Lu <perf.patrick.lu@gmail.com>