### PR TITLE
Save wprof.data disk space

### DIFF
--- a/src/wevent.h
+++ b/src/wevent.h
@@ -39,8 +39,8 @@ struct wevent {
 	u16 flags;
 	enum event_kind kind;
 	u32 task_id;
-	u32 cpu;
-	u32 numa_node;
+	u16 cpu;
+	u16 numa_node;
 	u64 ts;
 
 	union {
@@ -55,8 +55,8 @@ struct wevent {
 			u32 last_next_task_state;
 			u32 prev_prio;
 			u32 next_prio;
-			u32 waker_cpu;
-			u32 waker_numa_node;
+			u16 waker_cpu;
+			u16 waker_numa_node;
 			u32 next_task_scx_layer_id; /* sched-ext specific */
 			u32 next_task_scx_dsq_id; /* sched-ext specific */
 			u32 pystack_id;

--- a/src/wprof.bpf.h
+++ b/src/wprof.bpf.h
@@ -19,8 +19,8 @@
 struct task_state {
 	u64 waking_ts;
 	u32 waking_flags;
-	u32 waker_cpu;
-	u32 waker_numa_node;
+	u16 waker_cpu;
+	u16 waker_numa_node;
 	u32 last_task_state;
 	struct wprof_thread waker_task;
 	u64 softirq_ts;

--- a/src/wprof.h
+++ b/src/wprof.h
@@ -207,8 +207,8 @@ struct wprof_event {
 	enum event_kind kind;
 	u64 ts;
 
-	u32 cpu;
-	u32 numa_node;
+	u16 cpu;
+	u16 numa_node;
 	struct wprof_thread task;
 
 	char __wprof_data[0]; /* marker field */
@@ -222,8 +222,8 @@ struct wprof_event {
 			u32 last_next_task_state;
 			u32 prev_prio;
 			u32 next_prio;
-			u32 waker_cpu;
-			u32 waker_numa_node;
+			u16 waker_cpu;
+			u16 waker_numa_node;
 			enum waking_flags waking_flags;
 			int next_task_scx_layer_id; /* sched-ext specific */
 			int next_task_scx_dsq_id; /* sched-ext specific */


### PR DESCRIPTION
Compacting cpu and num_node fields from 4 bytes each to 2 bytes each. For hot callbacks (e.g py-trace) this saves ~20% of disk space.

```
New:
Replay info:
============
Data version:             3.0
Duration:                 2.000s (2000.000ms)
...
Data:                     14.625MB total
    Thread info:          0.125MB (6537 entries)
    Strings:              0.014MB (1083 unique strings)
    Events:               14.486MB (189211 records)
        switch            13.361MB (159200 records)
        hardirq           0.029MB (643 records)
        softirq           0.922MB (24158 records)
        wq                0.033MB (877 records)
        fork              0.005MB (202 records)
        exec              0.003MB (104 records)
        task_rename       0.005MB (193 records)
        task_exit         0.004MB (188 records)
        task_free         0.004MB (186 records)
        pytrace_entry     0.059MB (1730 records)
        pytrace_exit      0.059MB (1730 records)

Current:
Replay info:
============
Data version:             2.0
...
Data:                     18.585MB total
    Thread info:          0.120MB (6276 entries)
    Strings:              0.013MB (1025 unique strings)
    Events:               18.452MB (212183 records)
        switch            16.120MB (162525 records)
        hardirq           0.545MB (10198 records)
        softirq           1.584MB (34597 records)
        wq                0.044MB (965 records)
        fork              0.003MB (92 records)
        exec              0.002MB (60 records)
        task_rename       0.003MB (86 records)
        task_exit         0.003MB (100 records)
        task_free         0.003MB (100 records)
        pytrace_entry     0.073MB (1730 records)
        pytrace_exit      0.073MB (1730 records)
Exited cleanly (after 0.006s).

```