### PR TITLE
Optimize pytrace and CUDA perfetto track layouts

### DIFF
--- a/src/emit.c
+++ b/src/emit.c
@@ -98,7 +98,6 @@ enum track_special {
 
 	TKS_REQUESTS = 4,
 	TKS_CUDA = 5,
-	TKS_PYTRACE = 6,
 };
 
 #define TRACK_UUID(kind, id) (((u64)(id) * TK_MULT) + (u64)kind)
@@ -108,7 +107,6 @@ enum track_special {
 #define TRACK_UUID_KTHREAD	TRACK_UUID(TK_SPECIAL, TKS_KTHREAD)
 #define TRACK_UUID_REQUESTS	TRACK_UUID(TK_SPECIAL, TKS_REQUESTS)
 #define TRACK_UUID_CUDA		TRACK_UUID(TK_SPECIAL, TKS_CUDA)
-#define TRACK_UUID_PYTRACE	TRACK_UUID(TK_SPECIAL, TKS_PYTRACE)
 
 enum dyn_track_kind {
 	__DTK_GAP = TK_MULT - 1,	/* we need to not overlap with enum track_kind */
@@ -117,7 +115,6 @@ enum dyn_track_kind {
 	DTK_REQ,			/* single request of given PID (id1 = pid, id2 = req_id) */
 	DTK_REQ_THREAD,			/* request-participating thread (id1 = tid, id2 = req_id) */
 	DTK_REQ_THREAD_EMBED,		/* first-event-per-thread tracking for embed mode (id1 = tid, id2 = req_id) */
-	DTK_PYTRACE_PROC,	/* Python-traced process track (by PID) */
 	DTK_PYTRACE_PROC_THREAD,/* Python-traced thread track (by TID) */
 	DTK_UTRACE_THREAD,	/* utrace per-config track (id1 = tid, id2 = utrace_id) */
 	DTK_TIMER_THREAD,	/* per-thread timer track (id1 = tid) */
@@ -606,11 +603,6 @@ static inline u64 trackid_cuda_proc_gpu(int pid, u32 dev_id)
 static inline u64 trackid_cuda_proc_stream(int pid, u32 stream_id)
 {
 	return TRACK_UUID(TK_CUDA_PROC_STREAM, pid | ((u64)stream_id << 32));
-}
-
-static inline u64 trackid_pytrace_proc(int pid)
-{
-	return track_state_get_or_add(DTK_PYTRACE_PROC, pid, 0)->track_id;
 }
 
 static inline u64 trackid_pytrace_thread(int tid)
@@ -3392,29 +3384,16 @@ static int process_cuda_api(struct worker_state *w, const struct wevent *e)
 
 /* PYTRACE (Python function tracing) */
 
-static u64 ensure_pytrace_proc_track(int pid, const char *proc_name)
+static u64 ensure_pytrace_thread_track(int tid, const char *comm)
 {
-	struct track_state *s = track_state_get_or_add(DTK_PYTRACE_PROC, pid, 0);
-	u64 track_uuid = trackid_pytrace_proc(pid);
-
-	if (!s->exists) {
-		emit_track_descr_explicit(cur_stream, track_uuid, TRACK_UUID_PYTRACE,
-					  sfmt("%s %d", proc_name, pid), 0);
-		s->exists = true;
-	}
-	return track_uuid;
-}
-
-static u64 ensure_pytrace_thread_track(int pid, int tid, const char *proc_name, const char *comm)
-{
-	ensure_pytrace_proc_track(pid, proc_name);
-
 	struct track_state *s = track_state_get_or_add(DTK_PYTRACE_PROC_THREAD, tid, 0);
 	u64 track_uuid = trackid_pytrace_thread(tid);
 
 	if (!s->exists) {
-		emit_track_descr(cur_stream, track_uuid, trackid_pytrace_proc(pid),
-				 sfmt("%s %d", comm, tid), tid);
+		emit_track_descr_impl(cur_stream, track_uuid,
+				      TRACK_UUID(TK_THREAD_META, tid),
+				      comm, tid,
+				      CHILD_ORDER_CHRONO, MERGE_NONE);
 		s->exists = true;
 	}
 	return track_uuid;
@@ -3425,7 +3404,7 @@ static void emit_pytrace_event(struct worker_state *w, const struct wevent *e)
 	struct wprof_data_hdr *hdr = w->dump_hdr;
 	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
 
-	u64 track_uuid = ensure_pytrace_thread_track(task.pid, task.tid, task.pcomm, task.comm);
+	u64 track_uuid = ensure_pytrace_thread_track(task.tid, task.comm);
 
 	const char *func_name = wevent_str(hdr, e->pytrace.func_name_stroff);
 	const char *file = e->pytrace.file_name_stroff ? wevent_str(hdr, e->pytrace.file_name_stroff) : NULL;
@@ -3494,7 +3473,7 @@ static void emit_pytorch_event(struct worker_state *w, const struct wevent *e)
 	struct wprof_data_hdr *hdr = w->dump_hdr;
 	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
 
-	u64 track_uuid = ensure_pytrace_thread_track(task.pid, task.tid, task.pcomm, task.comm);
+	u64 track_uuid = ensure_pytrace_thread_track(task.tid, task.comm);
 
 	const char *name = e->rf.name_stroff ? wevent_str(hdr, e->rf.name_stroff) : "?";
 	pb_iid name_iid = emit_intern_str(w, name);
@@ -3990,8 +3969,6 @@ int emit_trace(struct worker_state *w)
 			emit_track_descr(cur_stream, TRACK_UUID_REQUESTS, 0, "REQUESTS", 1000);
 		if (env.capture_cuda)
 			emit_track_descr(cur_stream, TRACK_UUID_CUDA, 0, "CUDA", 2000);
-		if (env.capture_pytrace)
-			emit_track_descr(cur_stream, TRACK_UUID_PYTRACE, 0, "PYTRACE", 3000);
 
 		if (env.requested_stack_traces) {
 			struct wprof_stacks_hdr *shdr = wprof_stacks_hdr(w->dump_hdr);

--- a/src/emit.c
+++ b/src/emit.c
@@ -2992,6 +2992,10 @@ static int process_cuda_kernel(struct worker_state *w, const struct wevent *e)
 	if (env.capture_cuda != TRUE)
 		return 0;
 
+	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
+	if (!should_trace_task(&task))
+		return 0;
+
 	if (!is_time_range_in_session(e->ts, e->cuda_kernel.end_ts))
 		return 0;
 
@@ -3077,6 +3081,10 @@ static int process_cuda_memcpy(struct worker_state *w, const struct wevent *e)
 	if (env.capture_cuda != TRUE)
 		return 0;
 
+	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
+	if (!should_trace_task(&task))
+		return 0;
+
 	if (!is_time_range_in_session(e->ts, e->cuda_memcpy.end_ts))
 		return 0;
 
@@ -3149,6 +3157,10 @@ static void emit_cuda_memset_json(struct worker_state *w, const struct wevent *e
 static int process_cuda_memset(struct worker_state *w, const struct wevent *e)
 {
 	if (env.capture_cuda != TRUE)
+		return 0;
+
+	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
+	if (!should_trace_task(&task))
 		return 0;
 
 	if (!is_time_range_in_session(e->ts, e->cuda_memset.end_ts))
@@ -3241,6 +3253,10 @@ static void emit_cuda_sync_json(struct worker_state *w, const struct wevent *e)
 static int process_cuda_sync(struct worker_state *w, const struct wevent *e)
 {
 	if (env.capture_cuda != TRUE)
+		return 0;
+
+	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
+	if (!should_trace_task(&task))
 		return 0;
 
 	if (!is_time_range_in_session(e->ts, e->cuda_sync.end_ts))
@@ -3353,6 +3369,8 @@ static int process_cuda_api(struct worker_state *w, const struct wevent *e)
 		return 0;
 
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
+	if (!should_trace_task(&task))
+		return 0;
 
 	if (!is_time_range_in_session(e->ts, e->cuda_api.end_ts))
 		return 0;
@@ -3456,6 +3474,10 @@ static int process_pytrace(struct worker_state *w, const struct wevent *e)
 	if (env.capture_pytrace != TRUE)
 		return 0;
 
+	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
+	if (!should_trace_task(&task))
+		return 0;
+
 	if (!is_ts_in_range(e->ts))
 		return 0;
 
@@ -3504,6 +3526,10 @@ static void emit_pytorch_event_json(struct worker_state *w, const struct wevent 
 static int process_pytorch(struct worker_state *w, const struct wevent *e)
 {
 	if (env.capture_pytorch != TRUE)
+		return 0;
+
+	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
+	if (!should_trace_task(&task))
 		return 0;
 
 	if (!is_ts_in_range(e->ts))

--- a/src/emit.c
+++ b/src/emit.c
@@ -2789,6 +2789,14 @@ static int process_req_task_event(struct worker_state *w, const struct wevent *e
 	return 0;
 }
 
+/*
+ * Per-PID CUDA fallback track for orphan sync events that have no stream
+ * association (or reference a stream we never saw a kernel/memcpy/memset on,
+ * meaning we don't know its device). Emitted lazily from process_cuda_sync;
+ * the regular kernel/memcpy/memset paths attach directly to the GPU+stream
+ * tracks and never trigger this. PIDs without orphan syncs produce no
+ * fallback row, keeping the top-level CUDA folder clean.
+ */
 static u64 ensure_cuda_proc_track(int pid, const char *proc_name)
 {
 	struct track_state *s = track_state_get_or_add(TK_CUDA_PROC, pid, 0);
@@ -2808,21 +2816,21 @@ static u64 ensure_cuda_proc_gpu_track(int pid, u32 gpu_id)
 	u64 track_uuid = trackid_cuda_proc_gpu(pid, gpu_id);
 
 	if (!s->exists) {
-		emit_track_descr(cur_stream, track_uuid, trackid_cuda_proc(pid),
-				 sfmt("GPU #%u", gpu_id), 0);
+		emit_track_descr(cur_stream, track_uuid, TRACK_UUID_CUDA,
+				 sfmt("GPU #%u", gpu_id), gpu_id + 1);
 		s->exists = true;
 	}
 	return track_uuid;
 }
 
-static u64 ensure_cuda_proc_stream_track(int pid, u32 gpu_id, u32 stream_id)
+static u64 ensure_cuda_proc_stream_track(int pid, u32 gpu_id, u32 stream_id, const char *proc_name)
 {
 	struct track_state *s = track_state_get_or_add(TK_CUDA_PROC_STREAM, pid, stream_id);
 	u64 track_uuid = trackid_cuda_proc_stream(pid, stream_id);
 
 	if (!s->exists) {
 		emit_track_descr(cur_stream, track_uuid, trackid_cuda_proc_gpu(pid, gpu_id),
-				 sfmt("Stream #%u", stream_id), 0);
+				 sfmt("Stream #%u (%s %d)", stream_id, proc_name, pid), 0);
 		s->exists = true;
 	}
 	return track_uuid;
@@ -2908,9 +2916,8 @@ static void emit_cuda_kernel(struct worker_state *w, const struct wevent *e)
 	struct wprof_data_hdr *hdr = w->dump_hdr;
 	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
 
-	ensure_cuda_proc_track(task.pid, task.pcomm);
 	ensure_cuda_proc_gpu_track(task.pid, cu->device_id);
-	u64 track_uuid = ensure_cuda_proc_stream_track(task.pid, cu->device_id, cu->stream_id);
+	u64 track_uuid = ensure_cuda_proc_stream_track(task.pid, cu->device_id, cu->stream_id, task.pcomm);
 
 	const char *cuda_kern_name = wevent_str(hdr, cu->name_stroff);
 
@@ -3005,9 +3012,8 @@ static void emit_cuda_memcpy(struct worker_state *w, const struct wevent *e)
 	struct wprof_data_hdr *hdr = w->dump_hdr;
 	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
 
-	ensure_cuda_proc_track(task.pid, task.pcomm);
 	ensure_cuda_proc_gpu_track(task.pid, cu->device_id);
-	u64 track_uuid = ensure_cuda_proc_stream_track(task.pid, cu->device_id, cu->stream_id);
+	u64 track_uuid = ensure_cuda_proc_stream_track(task.pid, cu->device_id, cu->stream_id, task.pcomm);
 
 	pb_iid name_iid, kind_iid;
 	if (cu->copy_kind >= CUDA_MEMCPY_UNKN && cu->copy_kind < NR_CUDA_MEMCPY_KIND) {
@@ -3094,9 +3100,8 @@ static void emit_cuda_memset(struct worker_state *w, const struct wevent *e)
 	struct wprof_data_hdr *hdr = w->dump_hdr;
 	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
 
-	ensure_cuda_proc_track(task.pid, task.pcomm);
 	ensure_cuda_proc_gpu_track(task.pid, cu->device_id);
-	u64 track_uuid = ensure_cuda_proc_stream_track(task.pid, cu->device_id, cu->stream_id);
+	u64 track_uuid = ensure_cuda_proc_stream_track(task.pid, cu->device_id, cu->stream_id, task.pcomm);
 
 	pb_iid name_iid, kind_iid;
 	if (cu->mem_kind >= CUDA_MEM_UNKN && cu->mem_kind < NR_CUDA_MEMORY_KIND) {
@@ -3172,7 +3177,6 @@ static void emit_cuda_sync(struct worker_state *w, const struct wevent *e)
 	struct wprof_data_hdr *hdr = w->dump_hdr;
 	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
 
-	u64 proc_track_uuid = ensure_cuda_proc_track(task.pid, task.pcomm);
 	u64 track_uuid;
 
 	if ((int)cu->stream_id == -1 /* CUPTI_SYNCHRONIZATION_INVALID_VALUE */) {
@@ -3180,7 +3184,7 @@ static void emit_cuda_sync(struct worker_state *w, const struct wevent *e)
 		 * some SYNC events don't have stream association,
 		 * so we put them on "global" (CUDA) process track
 		 */
-		track_uuid = proc_track_uuid;
+		track_uuid = ensure_cuda_proc_track(task.pid, task.pcomm);
 	} else if (track_state_find(TK_CUDA_PROC_STREAM, task.pid, cu->stream_id)) {
 		/*
 		 * SYNC events don't record device ID (only in CUDA 13+, which we don't take
@@ -3193,7 +3197,7 @@ static void emit_cuda_sync(struct worker_state *w, const struct wevent *e)
 		 * otherwise we don't have GPU ID to ensure proper track structure, so put this
 		 * sync event on (CUDA) process track
 		 */
-		track_uuid = proc_track_uuid;
+		track_uuid = ensure_cuda_proc_track(task.pid, task.pcomm);
 	}
 
 	pb_iid name_iid, kind_iid;
@@ -3411,7 +3415,7 @@ static void emit_pytrace_event(struct worker_state *w, const struct wevent *e)
 	const char *base = file ? strrchr(file, '/') : NULL;
 	base = base ? base + 1 : file;
 
-	const char *display_name = base ? sfmt("%s(%u):%s", base, e->pytrace.lineno, func_name) : func_name;
+	const char *display_name = base ? sfmt("%s (%s:%u)", func_name, base, e->pytrace.lineno) : func_name;
 	pb_iid name_iid = emit_intern_str(w, display_name);
 
 	if (e->kind == EV_PYTRACE_ENTRY) {
@@ -3968,7 +3972,7 @@ int emit_trace(struct worker_state *w)
 		if (env.capture_requests)
 			emit_track_descr(cur_stream, TRACK_UUID_REQUESTS, 0, "REQUESTS", 1000);
 		if (env.capture_cuda)
-			emit_track_descr(cur_stream, TRACK_UUID_CUDA, 0, "CUDA", 2000);
+			emit_track_descr_explicit(cur_stream, TRACK_UUID_CUDA, 0, "CUDA", 2000);
 
 		if (env.requested_stack_traces) {
 			struct wprof_stacks_hdr *shdr = wprof_stacks_hdr(w->dump_hdr);

--- a/src/pydisc.c
+++ b/src/pydisc.c
@@ -105,7 +105,7 @@ int py_find_binary(int pid, struct py_binary_info *bi)
 	snprintf(exe_path, sizeof(exe_path), "/proc/%d/exe", pid);
 
 	if (stat(exe_path, &st)) {
-		eprintf("Failed to retrive file status for %s\n", exe_path);
+		vprintf("Failed to retrive file status for %s\n", exe_path);
 		return -errno;
 	}
 	/* Scan static executable or libpython*.so for Py_Version (or _PyRuntime for 3.10).


### PR DESCRIPTION
Three main changes:
1. fix the -p filter for replay mode for py-trace / cuda trace events
2. merge PYTRACE into per thread track as collapsible child track
3. re-order CUDA track to show GPU #N first, then streams (with process name and pid)

+1 minor change: makes python process discovery failure message in verbose mode (it's expected to fail for the most of non-python processes