### PR TITLE
emit: nest pytrace track under TK_THREAD for collapsible rendering

### DIFF
--- a/src/emit.c
+++ b/src/emit.c
@@ -3395,7 +3395,7 @@ static u64 ensure_pytrace_thread_track(int tid, const char *comm)
 
 	if (!s->exists) {
 		emit_track_descr_impl(cur_stream, track_uuid,
-				      TRACK_UUID(TK_THREAD_META, tid),
+				      TRACK_UUID(TK_THREAD, tid),
 				      comm, tid,
 				      CHILD_ORDER_CHRONO, MERGE_NONE);
 		s->exists = true;


### PR DESCRIPTION
The pytrace per-thread track was parented on TK_THREAD_META. While that is the semantically correct anchor for a thread's per-tid metadata, trace_processor treats META as a thread-metadata source rather than a slice track, so children with parent_uuid=META render as floating siblings of the kernel thread row instead of nested under it -- the "collapsible child row" behavior is lost in the UI.

Move parent_uuid to TK_THREAD (the kernel event track), matching the TIMER track pattern from 3e7a877 ("emit: move timer events to a separate non-merged TIMER child track"). MERGE_NONE still keeps the row from being absorbed into the parent by Perfetto's BY_TRACK_NAME default.

Result restored: pytrace appears as a collapsible nested child of the kernel thread row, hidden when the thread row is collapsed.