### PR TITLE
env: add --seal-output to lock down file output options

### DIFF
--- a/src/env.c
+++ b/src/env.c
@@ -96,6 +96,8 @@ enum {
 	OPT_REQ_FILTER = 3004,
 	OPT_REQ_TOP_N = 3005,
 	OPT_REQ_BOTTOM_N = 3006,
+
+	OPT_SEAL_OUTPUT = 4000,
 };
 
 static const struct argp_option opts[] = {
@@ -174,6 +176,7 @@ static const struct argp_option opts[] = {
 	{ "req-filter", OPT_REQ_FILTER, "EXPR", 0, "Filter requests: <field><op><value> (e.g., latency>1ms, pid=1234, name=foo). Repeatable." },
 	{ "req-top-n", OPT_REQ_TOP_N, "N", 0, "Show only the first N requests" },
 	{ "req-bottom-n", OPT_REQ_BOTTOM_N, "N", 0, "Show only the last N requests" },
+	{ "seal-output", OPT_SEAL_OUTPUT, NULL, OPTION_HIDDEN, "Prevent subsequent file-output options" },
 	{},
 };
 
@@ -262,6 +265,10 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 		env.duration_ns *= 1000000;
 		break;
 	case 'D':
+		if (env.output_sealed) {
+			fprintf(stderr, "Output file options are disabled by --seal-output\n");
+			return -EINVAL;
+		}
 		env.data_path = strdup(arg);
 		break;
 	case 'R':
@@ -285,6 +292,10 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 		}
 		break;
 	case 'T':
+		if (env.output_sealed) {
+			fprintf(stderr, "Output file options are disabled by --seal-output\n");
+			return -EINVAL;
+		}
 		if (env.trace_path || env.json_path) {
 			fprintf(stderr, "Only one trace output can be specified (-T and -J are mutually exclusive)!\n");
 			return -EINVAL;
@@ -292,6 +303,10 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 		env.trace_path = strdup(arg);
 		break;
 	case 'J':
+		if (env.output_sealed) {
+			fprintf(stderr, "Output file options are disabled by --seal-output\n");
+			return -EINVAL;
+		}
 		if (env.trace_path || env.json_path) {
 			fprintf(stderr, "Only one trace output can be specified (-T and -J are mutually exclusive)!\n");
 			return -EINVAL;
@@ -773,6 +788,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 		}
 		break;
 	}
+	case OPT_SEAL_OUTPUT:
+		env.output_sealed = true;
+		break;
 	case ARGP_KEY_ARG:
 		argp_usage(state);
 		break;

--- a/src/env.c
+++ b/src/env.c
@@ -98,6 +98,7 @@ enum {
 	OPT_REQ_BOTTOM_N = 3006,
 
 	OPT_SEAL_OUTPUT = 4000,
+	OPT_RECORD = 4001,
 };
 
 static const struct argp_option opts[] = {
@@ -113,7 +114,10 @@ static const struct argp_option opts[] = {
 	{ "json-trace", 'J', "FILE", 0, "Emit JSON trace to specified file (use '-' for stdout; see --json-schema)" },
 	{ "json-schema", OPT_JSON_SCHEMA, NULL, 0, "Print JSON output schema and exit" },
 
-	{ "replay", 'R', NULL, 0, "Re-process raw dump (no actual BPF data gathering)" },
+	{ "record", OPT_RECORD, NULL, 0, "Record mode (default, mutually exclusive with --replay)" },
+	{ "seal-output", OPT_SEAL_OUTPUT, NULL, OPTION_HIDDEN, "Prevent subsequent file-output options" },
+
+	{ "replay", 'R', NULL, 0, "Replay mode" },
 	{ "replay-start", OPT_REPLAY_OFFSET_START, "TIME_OFFSET", 0, "Session start time offset (replay mode only). Supported syntax: 2s, 1.03s, 10.5ms, 12us, 101213ns" },
 	{ "replay-end", OPT_REPLAY_OFFSET_END, "TIME_OFFSET", 0, "Session end time offset (replay mode only). Supported syntax: 2s, 1.03s, 10.5ms, 12us, 101213ns" },
 	{ "replay-info", 'I', NULL, 0, "Print recorded data information" },
@@ -176,7 +180,6 @@ static const struct argp_option opts[] = {
 	{ "req-filter", OPT_REQ_FILTER, "EXPR", 0, "Filter requests: <field><op><value> (e.g., latency>1ms, pid=1234, name=foo). Repeatable." },
 	{ "req-top-n", OPT_REQ_TOP_N, "N", 0, "Show only the first N requests" },
 	{ "req-bottom-n", OPT_REQ_BOTTOM_N, "N", 0, "Show only the last N requests" },
-	{ "seal-output", OPT_SEAL_OUTPUT, NULL, OPTION_HIDDEN, "Prevent subsequent file-output options" },
 	{},
 };
 
@@ -272,6 +275,10 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 		env.data_path = strdup(arg);
 		break;
 	case 'R':
+		if (env.record) {
+			fprintf(stderr, "Only one of --record or --replay modes should be enabled\n");
+			return -EINVAL;
+		}
 		env.replay = true;
 		break;
 	case 'I':
@@ -788,6 +795,13 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 		}
 		break;
 	}
+	case OPT_RECORD:
+		if (env.replay) {
+			fprintf(stderr, "Only one of --record or --replay modes should be enabled\n");
+			return -EINVAL;
+		}
+		env.record = true;
+		break;
 	case OPT_SEAL_OUTPUT:
 		env.output_sealed = true;
 		break;

--- a/src/env.h
+++ b/src/env.h
@@ -60,6 +60,7 @@ struct env {
 	int debug_level;
 	enum log_subset log_set;
 	bool stats;
+	bool record;
 	bool replay;
 	bool replay_info;
 	bool symbolize_frugally;

--- a/src/env.h
+++ b/src/env.h
@@ -121,6 +121,7 @@ struct env {
 	char *data_path;
 	char *trace_path;
 	char *json_path;
+	bool output_sealed;
 
 	bool pb_debug_interns;
 	bool pb_disable_interns;

--- a/src/wprof.c
+++ b/src/wprof.c
@@ -847,6 +847,7 @@ static int setup_bpf(struct bpf_state *st, struct worker_state *workers, int num
 	}
 
 	st->rb_map_fds = calloc(env.ringbuf_cnt, sizeof(*st->rb_map_fds));
+	u32 *rb_keys = calloc(env.ringbuf_cnt, sizeof(*rb_keys));
 	for (int i = 0; i < env.ringbuf_cnt; i++) {
 		int map_fd;
 
@@ -856,14 +857,18 @@ static int setup_bpf(struct bpf_state *st, struct worker_state *workers, int num
 			return map_fd;
 		}
 
-		err = bpf_map_update_elem(bpf_map__fd(skel->maps.rbs), &i, &map_fd, BPF_NOEXIST);
-		if (err < 0) {
-			eprintf("Failed to set BPF ringbuf #%d into ringbuf map-of-maps: %d\n", i, err);
-			close(map_fd);
-			return err;
-		}
-
+		rb_keys[i] = i;
 		st->rb_map_fds[i] = map_fd;
+	}
+
+	u32 rb_cnt = env.ringbuf_cnt;
+	LIBBPF_OPTS(bpf_map_batch_opts, batch_opts);
+	err = bpf_map_update_batch(bpf_map__fd(skel->maps.rbs), rb_keys, st->rb_map_fds,
+				   &rb_cnt, &batch_opts);
+	free(rb_keys);
+	if (err < 0) {
+		eprintf("Failed to set BPF ringbufs into ringbuf map-of-maps: %d\n", err);
+		return err;
 	}
 
 	/* Prepare ring buffers to receive events from the BPF program. */


### PR DESCRIPTION
Add a hidden --seal-output flag that prevents any subsequent -D, -T, or -J options from being accepted. This is intended for partially untrusted environments where a trusted runner controls file output locations (by placing -D/-T/-J before --seal-output) but allows untrusted users to append extra filtering, mode, or utrace options without being able to redirect output to arbitrary paths.

Since argp processes options left-to-right, the flag works as a simple boolean gate checked before each file-output option.