### PR TITLE
utrace: fix @file parsing that stripped entire line content

### DIFF
--- a/src/utrace_cfg.c
+++ b/src/utrace_cfg.c
@@ -630,7 +630,7 @@ int utrace_cfg_parse_file(const char *path)
 		line_nr++;
 
 		/* strip newline */
-		while (line_len > 0 && line[line_len - 1])
+		while (line_len > 0 && isspace(line[line_len - 1]))
 			line[--line_len] = '\0';
 
 		/* skip blank lines and comments */


### PR DESCRIPTION
The newline-stripping loop condition checked for any non-null byte, emptying every line. Fix by checking isspace() instead.