### PR TITLE
wprof: add arm64 IPI receive-side tracking support

### DIFF
--- a/src/wprof.bpf.c
+++ b/src/wprof.bpf.c
@@ -1169,8 +1169,6 @@ int BPF_PROG(wprof_wq_exec_end, struct work_struct *work /* , work_func_t functi
 	return handle_workqueue(now_ts, task, work, false /*!start*/);
 }
 
-#ifdef __TARGET_ARCH_x86
-
 static struct cpu_state all_cpus_state;
 
 static int handle_ipi_send(u64 now_ts, struct task_struct *task,
@@ -1227,10 +1225,7 @@ int BPF_PROG(wprof_ipi_send_mask, struct cpumask *mask)
 	return handle_ipi_send(now_ts, task, IPI_MULTI, -1);
 }
 
-#define RESCHEDULE_VECTOR		0xfd
-#define CALL_FUNCTION_VECTOR		0xfc
-#define CALL_FUNCTION_SINGLE_VECTOR	0xfb
-
+__attribute__((unused))
 static int handle_ipi(u64 now_ts, struct task_struct *task, enum wprof_ipi_kind ipi_kind, bool start)
 {
 	struct cpu_state *s;
@@ -1284,6 +1279,12 @@ static int handle_ipi(u64 now_ts, struct task_struct *task, enum wprof_ipi_kind 
 
 	return 0;
 }
+
+#if defined(__TARGET_ARCH_x86)
+
+#define RESCHEDULE_VECTOR		0xfd
+#define CALL_FUNCTION_VECTOR		0xfc
+#define CALL_FUNCTION_SINGLE_VECTOR	0xfb
 
 SEC("?tp_btf/call_function_entry")
 int BPF_PROG(wprof_ipi_multi_entry, int vector)
@@ -1387,7 +1388,64 @@ int BPF_PROG(wprof_ipi_resched_exit, int vector)
 	return handle_ipi(now_ts, task, IPI_RESCHED, false /*!start*/);
 }
 
-#endif /* __TARGET_ARCH_x86 */
+#elif defined(__TARGET_ARCH_arm64)
+
+/*
+ * arm64 ipi_entry/ipi_exit tracepoints pass a reason string from
+ * ipi_types[] array. We only need the first character to distinguish:
+ *   'R' -> "Rescheduling interrupts"  -> IPI_RESCHED
+ *   'F' -> "Function call interrupts" -> IPI_SINGLE (no single vs multi distinction on arm64)
+ */
+static __always_inline enum wprof_ipi_kind ipi_reason_to_kind(const char *reason)
+{
+	char c = 0;
+	bpf_probe_read_kernel(&c, 1, reason);
+	switch (c) {
+	case 'R': return IPI_RESCHED;
+	case 'F': return IPI_SINGLE;
+	default: return IPI_INVALID;
+	}
+}
+
+SEC("?tp_btf/ipi_entry")
+int BPF_PROG(wprof_ipi_entry, const char *reason)
+{
+	u64 now_ts;
+	struct task_struct *task;
+	enum wprof_ipi_kind kind;
+
+	kind = ipi_reason_to_kind(reason);
+	if (kind == IPI_INVALID)
+		return 0;
+
+	now_ts = bpf_ktime_get_ns();
+	task = bpf_get_current_task_btf();
+	if (!should_trace_task(task, now_ts))
+		return 0;
+
+	return handle_ipi(now_ts, task, kind, true /*start*/);
+}
+
+SEC("?tp_btf/ipi_exit")
+int BPF_PROG(wprof_ipi_exit, const char *reason)
+{
+	u64 now_ts;
+	struct task_struct *task;
+	enum wprof_ipi_kind kind;
+
+	kind = ipi_reason_to_kind(reason);
+	if (kind == IPI_INVALID)
+		return 0;
+
+	now_ts = bpf_ktime_get_ns();
+	task = bpf_get_current_task_btf();
+	if (!should_trace_task(task, now_ts))
+		return 0;
+
+	return handle_ipi(now_ts, task, kind, false /*!start*/);
+}
+
+#endif
 
 struct req_state {
 	u64 start_ts;

--- a/src/wprof.c
+++ b/src/wprof.c
@@ -469,12 +469,12 @@ static int setup_bpf(struct bpf_state *st, struct worker_state *workers, int num
 	struct wprof_bpf *skel;
 	int i, err = 0;
 
-#ifndef __x86_64__
+#if !defined(__x86_64__) && !defined(__aarch64__)
 	if (env.capture_ipis) {
-		eprintf("IPI capture is supported only on x86-64 architecture!\n");
+		eprintf("IPI capture is supported only on x86-64 and arm64 architectures!\n");
 		return -EOPNOTSUPP;
 	}
-#endif /* __x86_64 */
+#endif
 
 	libbpf_set_print(libbpf_print_fn);
 
@@ -493,18 +493,21 @@ static int setup_bpf(struct bpf_state *st, struct worker_state *workers, int num
 		return err;
 	}
 
-#ifdef __x86_64__
 	if (env.capture_ipis) {
 		bpf_program__set_autoload(skel->progs.wprof_ipi_send_cpu, true);
 		bpf_program__set_autoload(skel->progs.wprof_ipi_send_mask, true);
+#if defined(__x86_64__)
 		bpf_program__set_autoload(skel->progs.wprof_ipi_single_entry, true);
 		bpf_program__set_autoload(skel->progs.wprof_ipi_single_exit, true);
 		bpf_program__set_autoload(skel->progs.wprof_ipi_multi_entry, true);
 		bpf_program__set_autoload(skel->progs.wprof_ipi_multi_exit, true);
 		bpf_program__set_autoload(skel->progs.wprof_ipi_resched_entry, true);
 		bpf_program__set_autoload(skel->progs.wprof_ipi_resched_exit, true);
-	}
+#elif defined(__aarch64__)
+		bpf_program__set_autoload(skel->progs.wprof_ipi_entry, true);
+		bpf_program__set_autoload(skel->progs.wprof_ipi_exit, true);
 #endif
+	}
 
 	if (env.capture_softirq) {
 		bpf_program__set_autoload(skel->progs.wprof_softirq_entry, true);


### PR DESCRIPTION
IPI receive-side tracking was previously x86-64 only, relying on arch-specific tracepoints (call_function_{entry,exit}, call_function_single_{entry,exit}, reschedule_{entry,exit}).

Add arm64 support using ipi_entry/ipi_exit tracepoints available via CONFIG_HAVE_EXTRA_IPI_TRACEPOINTS. These tracepoints pass a reason string from the kernel's ipi_types[] array, which we classify by its first character: 'R' for IPI_RESCHED, 'F' for IPI_SINGLE.

Note: arm64 doesn't distinguish single vs multi call function IPIs at the receive side (both arrive as "Function call interrupts"), so all call-function IPIs are mapped to IPI_SINGLE. Send-side correlation via ipi_send_cpu still works for single-target IPIs; multi-target IPIs will lack sender correlation.