### PR TITLE
proc: extract gpu_pid_iter for nvidia-smi PID enumeration

### DIFF
--- a/src/cuda.c
+++ b/src/cuda.c
@@ -160,7 +160,6 @@ int cuda_trace_setup(int workdir_fd)
 {
 	int err = 0;
 
-retry:
 	switch (env.cuda_discovery) {
 	case CUDA_DISCOVER_PROC: {
 		int *pidp, pid;
@@ -179,20 +178,9 @@ retry:
 	case CUDA_DISCOVER_SMI: {
 		vprintf("Using nvidia-smi to find processes using CUDA...\n");
 
-		FILE *f = popen("nvidia-smi --query-compute-apps=pid --format=csv,noheader", "r");
-		if (!f) {
-			eprintf("Failed to query nvidia-smi, falling back to process discovery logic...\n");
-			env.cuda_discovery = CUDA_DISCOVER_PROC;
-			goto retry;
-		}
-
-		char pidbuf[32];
-		int pid;
-		while (fgets(pidbuf, sizeof(pidbuf), f)) {
-			if (sscanf(pidbuf, "%d", &pid) != 1) {
-				eprintf("nvidia-smi returned invalid PID '%s', skipping...\n", pidbuf);
-				continue;
-			}
+		int *pidp;
+		wprof_for_each(gpu_pid, pidp) {
+			int pid = *pidp;
 			vprintf("nvidia-smi returned PID %d (%s)\n", pid, proc_name(pid));
 
 			bool found = false;
@@ -212,8 +200,6 @@ retry:
 				continue;
 			}
 		}
-
-		pclose(f);
 		break;
 	}
 	case CUDA_DISCOVER_NONE: {

--- a/src/proc.c
+++ b/src/proc.c
@@ -6,6 +6,7 @@
 #include <linux/fs.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <sys/ioctl.h>
 #include <dirent.h>
 #include <fcntl.h>
@@ -352,4 +353,51 @@ void vma_iter_destroy(struct vma_iter *it)
 	}
 
 	errno = old_errno;
+}
+
+int gpu_pid_iter_new(struct gpu_pid_iter *it)
+{
+	memset(it, 0, sizeof(*it));
+	it->f = popen("nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null", "r");
+	if (!it->f) {
+		wprintf("Failed to invoke nvidia-smi: %s\n", strerror(errno));
+		return -errno;
+	}
+	return 0;
+}
+
+int *gpu_pid_iter_next(struct gpu_pid_iter *it)
+{
+	if (!it->f)
+		return NULL;
+
+	char pidbuf[32];
+	while (fgets(pidbuf, sizeof(pidbuf), it->f)) {
+		if (sscanf(pidbuf, "%d", &it->cur_pid) != 1) {
+			eprintf("nvidia-smi returned invalid PID '%s', skipping...\n", pidbuf);
+			continue;
+		}
+		return &it->cur_pid;
+	}
+	return NULL;
+}
+
+void gpu_pid_iter_destroy(struct gpu_pid_iter *it)
+{
+	if (!it || !it->f)
+		return;
+	int status = pclose(it->f);
+	it->f = NULL;
+
+	if (status == -1) {
+		wprintf("nvidia-smi: pclose failed: %s\n", strerror(errno));
+	} else if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
+		int code = WEXITSTATUS(status);
+		if (code == 127)
+			wprintf("nvidia-smi not found in PATH; no GPU PIDs discovered\n");
+		else
+			wprintf("nvidia-smi exited with status %d; no GPU PIDs discovered\n", code);
+	} else if (WIFSIGNALED(status)) {
+		wprintf("nvidia-smi terminated by signal %d\n", WTERMSIG(status));
+	}
 }

--- a/src/proc.h
+++ b/src/proc.h
@@ -72,4 +72,14 @@ int vma_iter_new(struct vma_iter *it, int pid, enum vma_query_flags query_flags)
 struct vma_info *vma_iter_next(struct vma_iter *it);
 void vma_iter_destroy(struct vma_iter *it);
 
+/* Streams PIDs from `nvidia-smi --query-compute-apps=pid`; use with wprof_for_each(gpu_pid, p). */
+struct gpu_pid_iter {
+	FILE *f;
+	int cur_pid;
+};
+
+int gpu_pid_iter_new(struct gpu_pid_iter *it);
+int *gpu_pid_iter_next(struct gpu_pid_iter *it);
+void gpu_pid_iter_destroy(struct gpu_pid_iter *it);
+
 #endif /* __PROC_H__ */

--- a/src/pydisc.c
+++ b/src/pydisc.c
@@ -283,23 +283,11 @@ static void discover_nvidia_smi(struct wprof_bpf *skel)
 {
 	vprintf("Using nvidia-smi to find GPU Python processes...\n");
 
-	FILE *f = popen("nvidia-smi --query-compute-apps=pid --format=csv,noheader", "r");
-	if (!f) {
-		eprintf("Failed to query nvidia-smi for Python process discovery\n");
-		return;
+	int *pidp;
+	wprof_for_each(gpu_pid, pidp) {
+		vprintf("nvidia-smi returned PID %d (%s)\n", *pidp, proc_name(*pidp));
+		discover_pid(*pidp, skel, true);
 	}
-
-	char pidbuf[32];
-	int pid;
-	while (fgets(pidbuf, sizeof(pidbuf), f)) {
-		if (sscanf(pidbuf, "%d", &pid) != 1) {
-			eprintf("nvidia-smi returned invalid PID '%s', skipping...\n", pidbuf);
-			continue;
-		}
-		vprintf("nvidia-smi returned PID %d (%s)\n", pid, proc_name(pid));
-		discover_pid(pid, skel, true);
-	}
-	pclose(f);
 }
 
 int pydisc_discover(struct wprof_bpf *skel)

--- a/src/pytrace.c
+++ b/src/pytrace.c
@@ -223,7 +223,6 @@ err_retract:
 
 int pytrace_trace_setup(int workdir_fd)
 {
-retry:
 	switch (env.pytrace_discovery) {
 	case PYTRACE_DISCOVER_PROC: {
 		int *pidp, pid;
@@ -237,23 +236,9 @@ retry:
 	case PYTRACE_DISCOVER_NVIDIA_SMI: {
 		vprintf("Using nvidia-smi to find Python processes using GPU...\n");
 
-		FILE *f = popen("nvidia-smi --query-compute-apps=pid --format=csv,noheader", "r");
-		if (!f) {
-			eprintf("Failed to query nvidia-smi, falling back to process discovery logic...\n");
-			env.pytrace_discovery = PYTRACE_DISCOVER_PROC;
-			goto retry;
-		}
-
-		char pidbuf[32];
-		int pid;
-		while (fgets(pidbuf, sizeof(pidbuf), f)) {
-			if (sscanf(pidbuf, "%d", &pid) != 1)
-				continue;
-
-			try_inject_to_python_process(pid, workdir_fd);
-		}
-
-		pclose(f);
+		int *pidp;
+		wprof_for_each(gpu_pid, pidp)
+			try_inject_to_python_process(*pidp, workdir_fd);
 		break;
 	}
 	case PYTRACE_DISCOVER_NONE:


### PR DESCRIPTION
Three sites (pydisc, cuda, pytrace) had near-identical popen + fgets + sscanf loops over 'nvidia-smi --query-compute-apps=pid'. Move the parsing into proc.h as a streaming iterator following the existing proc_iter / vma_iter style so callers use wprof_for_each(gpu_pid, p). Per-call-site behavior (verbose logging, per-PID action) stays at the call site.

Behavior change: cuda.c and pytrace.c previously had a fallback to *_DISCOVER_PROC if 'popen' returned NULL. That fallback is dropped: the popen-NULL branch was already unreachable for the common 'nvidia-smi not installed' case (popen succeeds; the spawned shell exits 127 and the iterator yields zero PIDs). Detection of that case now lives in the iterator itself: gpu_pid_iter_destroy inspects 'pclose' status and warns (e.g. 'nvidia-smi not found in PATH; no GPU PIDs discovered'), so users opting into nvidia-smi discovery on a host without it see a warning instead of silent zero output.