### PR TITLE
utrace: auto-discover GPU PIDs for uprobes via nvidia-smi

### DIFF
--- a/UTRACE.md
+++ b/UTRACE.md
@@ -34,6 +34,9 @@ wprof -U 'usdt:app:req_start (arg:0) ~~ usdt:app:req_end (arg:0)'
 
 # multiple probes from a config file
 wprof -U @probes.utrace
+
+# auto resolve pid via nvidia-smi
+wprof -U 'usdt:myapp:request_start (arg:0, pid:nvidia-smi)'
 ```
 
 ## Probe types
@@ -135,6 +138,18 @@ Captures the call stack when the probe fires. Enable stack output with
 
 For generic spans with USDT, `path:`/`pid:` on the first probe are
 inherited by the second.
+
+#### Auto-discovery (USDT only)
+
+- `pid:nvidia-smi` -- attach to every GPU process reported by
+  `nvidia-smi --query-compute-apps=pid`. The cfg is expanded at setup
+  time into one concrete attachment per discovered PID; PIDs that don't
+  expose the requested USDT are skipped with a warning. Setup fails only
+  if no discovered PID exposes the USDT. Example:
+
+  ```
+  wprof -U 'usdt:myapp:request_start (arg:0, pid:nvidia-smi)'
+  ```
 
 ## Settings
 

--- a/src/utrace.c
+++ b/src/utrace.c
@@ -168,6 +168,15 @@ static int cfg_pid(const struct utrace_cfg *cfg)
 	return -1; /* system-wide */
 }
 
+static enum utrace_pid_discovery cfg_pid_discovery(const struct utrace_cfg *cfg)
+{
+	for (int i = 0; i < cfg->param_cnt; i++) {
+		if (cfg->params[i].type == UTRACE_PARAM_PID_DISCOVERY)
+			return cfg->params[i].pid_discovery.method;
+	}
+	return UTRACE_PID_DISCOVER_NONE;
+}
+
 static bool cfg_is_kprobe_type(const struct utrace_cfg *cfg)
 {
 	switch (cfg->type) {
@@ -877,6 +886,10 @@ static int resolve_uprobe_binary(int pid, const char *sym_name,
  */
 static int resolve_uprobe_cfg(struct utrace_cfg *cfg)
 {
+	/* already resolved by utrace_expand_pid_discovery() */
+	if (cfg->uprobe.attach_path)
+		return 0;
+
 	const char *binary_path = cfg_binary_path(cfg);
 	int pid = cfg_pid(cfg);
 	unsigned long sym_offset = 0;
@@ -955,6 +968,10 @@ static int resolve_usdt_binary(int pid, const char *provider, const char *name,
 
 static int resolve_usdt_cfg(struct utrace_cfg *cfg)
 {
+	/* already resolved by utrace_expand_pid_discovery() */
+	if (cfg->usdt.attach_path)
+		return 0;
+
 	const char *binary_path = cfg_binary_path(cfg);
 	int pid = cfg_pid(cfg);
 
@@ -1090,8 +1107,175 @@ out:
 	return err;
 }
 
+static int clone_cfg_with_pid(const struct utrace_cfg *src,
+			      struct utrace_cfg *dst, int pid)
+{
+	*dst = *src;
+
+	switch (src->type) {
+	case UTRACE_USDT:
+		dst->usdt.provider = strdup(src->usdt.provider);
+		dst->usdt.name = strdup(src->usdt.name);
+		dst->usdt.attach_path = NULL;
+		dst->usdt.display_path = NULL;
+		memset(&dst->usdt.info, 0, sizeof(dst->usdt.info));
+		break;
+	case UTRACE_UPROBE:
+	case UTRACE_URETPROBE:
+	case UTRACE_UPROBE_SPAN:
+		dst->uprobe.name = strdup(src->uprobe.name);
+		dst->uprobe.attach_path = NULL;
+		dst->uprobe.display_path = NULL;
+		dst->uprobe.attach_off = 0;
+		break;
+	default:
+		break;
+	}
+
+	dst->settings.id = src->settings.id ? strdup(src->settings.id) : NULL;
+	dst->settings.name_fmt = src->settings.name_fmt ? strdup(src->settings.name_fmt) : NULL;
+	dst->settings.name_segs = NULL;
+	dst->settings.name_seg_cnt = 0;
+
+	dst->params = calloc(src->param_cnt, sizeof(*dst->params));
+	dst->param_cnt = src->param_cnt;
+
+	for (int i = 0; i < src->param_cnt; i++) {
+		const struct utrace_param *sp = &src->params[i];
+		struct utrace_param *dp = &dst->params[i];
+
+		if (sp->type == UTRACE_PARAM_PID_DISCOVERY) {
+			dp->type = UTRACE_PARAM_PID;
+			dp->pid.pid = pid;
+			continue;
+		}
+
+		*dp = *sp;
+		switch (sp->type) {
+		case UTRACE_PARAM_ARG:
+			dp->arg.name = sp->arg.name ? strdup(sp->arg.name) : NULL;
+			dp->arg.ref_name = sp->arg.ref_name ? strdup(sp->arg.ref_name) : NULL;
+			break;
+		case UTRACE_PARAM_BINARY_PATH:
+			dp->binary.path = sp->binary.path ? strdup(sp->binary.path) : NULL;
+			break;
+		default:
+			break;
+		}
+	}
+	return 0;
+}
+
+/*
+ * Automatically discover uprobe-family probe PIDs (currently only nvidia-smi).
+ * Streams the PID iterator once and, for each PID, fans out into the discovery
+ * cfgs. Mutates env.utrace_cfgs and env.utrace_cfg_cnt in place.
+ */
+static int utrace_expand_pid_discovery(void)
+{
+	struct utrace_cfg *concrete_cfgs = NULL;
+	int concrete_cnt = 0;
+	bool has_discovery = false;
+
+	/*
+	 * Copy PID-known cfgs straight through; discovery cfgs are expanded
+	 * per streamed PID in the second pass.
+	 */
+	for (int i = 0; i < env.utrace_cfg_cnt; i++) {
+		struct utrace_cfg *src = &env.utrace_cfgs[i];
+		if (cfg_pid_discovery(src) != UTRACE_PID_DISCOVER_NONE) {
+			has_discovery = true;
+			continue;
+		}
+		concrete_cfgs = realloc(concrete_cfgs, (concrete_cnt + 1) * sizeof(*concrete_cfgs));
+		concrete_cfgs[concrete_cnt++] = *src;
+	}
+
+	if (has_discovery) {
+		int total_pids = 0, total_attached = 0;
+
+		vprintf("Using nvidia-smi to discover GPU PIDs for USDT probes...\n");
+		int *pidp;
+		wprof_for_each(gpu_pid, pidp) {
+			int pid = *pidp;
+			total_pids++;
+			vprintf("nvidia-smi returned PID %d (%s)\n", pid, proc_name(pid));
+
+			for (int i = 0; i < env.utrace_cfg_cnt; i++) {
+				struct utrace_cfg *src = &env.utrace_cfgs[i];
+				if (cfg_pid_discovery(src) == UTRACE_PID_DISCOVER_NONE)
+					continue;
+				struct utrace_cfg cand;
+				clone_cfg_with_pid(src, &cand, pid);
+				int err = (src->type == UTRACE_USDT)
+					? resolve_usdt_cfg(&cand)
+					: resolve_uprobe_cfg(&cand);
+				if (err) {
+					wprintf("utrace: skipping PID %d (%s)\n", pid, proc_name(pid));
+					continue;
+				}
+				concrete_cfgs = realloc(concrete_cfgs, (concrete_cnt + 1) * sizeof(*concrete_cfgs));
+				concrete_cfgs[concrete_cnt++] = cand;
+				total_attached++;
+			}
+		}
+
+		if (total_pids == 0) {
+			for (int i = 0; i < env.utrace_cfg_cnt; i++) {
+				struct utrace_cfg *src = &env.utrace_cfgs[i];
+				if (cfg_pid_discovery(src) == UTRACE_PID_DISCOVER_NONE)
+					continue;
+				if (src->type == UTRACE_USDT)
+					wprintf("utrace: nvidia-smi returned no PIDs, dropping USDT '%s:%s'\n",
+						src->usdt.provider, src->usdt.name);
+				else
+					wprintf("utrace: nvidia-smi returned no PIDs, dropping uprobe '%s'\n",
+						src->uprobe.name);
+			}
+		} else if (total_attached == 0) {
+			eprintf("utrace: no GPU PID exposes any discovery probe (tried %d candidate(s) from nvidia-smi)\n",
+				total_pids);
+			free(concrete_cfgs);
+			return -ENOENT;
+		}
+	}
+
+	free(env.utrace_cfgs);
+	env.utrace_cfgs = concrete_cfgs;
+	env.utrace_cfg_cnt = concrete_cnt;
+	return 0;
+}
+
 int utrace_setup(struct wprof_bpf *skel)
 {
+	int err = utrace_expand_pid_discovery();
+	if (err) {
+		eprintf("Failed to expand utrace PID discovery: %d\n", err);
+		return err;
+	}
+
+	if (env.utrace_cfg_cnt == 0) {
+		env.capture_utrace = FALSE;
+		env.requested_stack_traces &= ~ST_UTRACE;
+		bpf_map__set_autocreate(skel->maps.utrace_probe_cfgs, false);
+		bpf_map__set_autocreate(skel->maps.utrace_scratch, false);
+		return 0;
+	}
+
+	env.capture_utrace = TRUE;
+
+	if (!(env.requested_stack_traces & ST_UTRACE)) {
+		for (int i = 0; i < env.utrace_cfg_cnt; i++) {
+			const struct utrace_cfg *cfg = &env.utrace_cfgs[i];
+			for (int j = 0; j < cfg->param_cnt; j++) {
+				if (cfg->params[j].type == UTRACE_PARAM_CAPTURE_STACK) {
+					eprintf("utrace config #%d requests 'stack' capture, but -Sutrace is not enabled\n", i + 1);
+					return -EINVAL;
+				}
+			}
+		}
+	}
+
 	bool need_fentry = false, need_fexit = false;
 	int first_prog_fd = -1;
 	const char *first_func_name = NULL;

--- a/src/utrace_cfg.c
+++ b/src/utrace_cfg.c
@@ -202,12 +202,17 @@ static int parse_params(struct sview orig, struct sview def, struct utrace_param
 		} else if (sv_starts_with(param, "pid:")) {
 			param = sv_trim(sv_consume_left(param, 4));
 
-			long pid = -1;
-			if (!sv_as_long(param, &pid) || pid <= 0 || pid > INT_MAX)
-				return utrace_err(orig, param, "invalid PID value\n");
+			if (sv_eq(param, "nvidia-smi")) {
+				p->type = UTRACE_PARAM_PID_DISCOVERY;
+				p->pid_discovery.method = UTRACE_PID_DISCOVER_NVIDIA_SMI;
+			} else {
+				long pid = -1;
+				if (!sv_as_long(param, &pid) || pid <= 0 || pid > INT_MAX)
+					return utrace_err(orig, param, "invalid PID value\n");
 
-			p->type = UTRACE_PARAM_PID;
-			p->pid.pid = (int)pid;
+				p->type = UTRACE_PARAM_PID;
+				p->pid.pid = (int)pid;
+			}
 		} else if (sv_starts_with(param, "arg:")) {
 			param = sv_trim(sv_consume_left(param, 4));
 			int err = parse_arg_param(orig, param, p);
@@ -257,6 +262,8 @@ static bool is_span_probe(enum utrace_type t)
 
 static int validate_probe_def(struct sview orig, const struct utrace_cfg *cfg)
 {
+	int pid_param_cnt = 0;
+
 	for (int i = 0; i < cfg->param_cnt; i++) {
 		const struct utrace_param *p = &cfg->params[i];
 
@@ -268,7 +275,14 @@ static int validate_probe_def(struct sview orig, const struct utrace_cfg *cfg)
 		}
 		if (p->type == UTRACE_PARAM_BINARY_PATH && !is_uprobe(cfg->type))
 			return utrace_err(orig, orig, "'path' parameter is only valid for uprobe-based probes\n");
+		if (p->type == UTRACE_PARAM_PID_DISCOVERY && !is_uprobe(cfg->type))
+			return utrace_err(orig, orig, "'pid:nvidia-smi' is only valid for uprobe-based probes (u/uret/uspan/usdt)\n");
+		if (p->type == UTRACE_PARAM_PID || p->type == UTRACE_PARAM_PID_DISCOVERY)
+			pid_param_cnt++;
 	}
+
+	if (pid_param_cnt > 1)
+		return utrace_err(orig, orig, "only one 'pid:' parameter is allowed per probe\n");
 
 	return 0;
 }
@@ -728,6 +742,15 @@ static void format_probe(const struct utrace_cfg *cfg, struct sbuf *sb)
 				break;
 			case UTRACE_PARAM_PID:
 				sbuf_appendf(sb, "pid:%d", p->pid.pid);
+				break;
+			case UTRACE_PARAM_PID_DISCOVERY:
+				switch (p->pid_discovery.method) {
+				case UTRACE_PID_DISCOVER_NONE:
+					break;
+				case UTRACE_PID_DISCOVER_NVIDIA_SMI:
+					sbuf_appendf(sb, "pid:nvidia-smi");
+					break;
+				}
 				break;
 			case UTRACE_PARAM_ARG:
 				if (p->arg.arg_idx == UTRACE_ARG_RET)

--- a/src/utrace_cfg.h
+++ b/src/utrace_cfg.h
@@ -57,6 +57,12 @@ enum utrace_param_type {
 	UTRACE_PARAM_CAPTURE_STACK = 1000,
 	UTRACE_PARAM_BINARY_PATH,
 	UTRACE_PARAM_PID,
+	UTRACE_PARAM_PID_DISCOVERY,
+};
+
+enum utrace_pid_discovery {
+	UTRACE_PID_DISCOVER_NONE = 0,
+	UTRACE_PID_DISCOVER_NVIDIA_SMI,
 };
 
 #define UTRACE_ARG_RET (-1)
@@ -90,6 +96,9 @@ struct utrace_param {
 		struct {
 			int pid;
 		} pid;
+		struct {
+			enum utrace_pid_discovery method;
+		} pid_discovery;
 	};
 };
 

--- a/src/wprof.c
+++ b/src/wprof.c
@@ -792,32 +792,10 @@ static int setup_bpf(struct bpf_state *st, struct worker_state *workers, int num
 		return err;
 	}
 
-	if (env.utrace_cfg_cnt > 0) {
-		env.capture_utrace = TRUE;
-
-		/* Validate: if any utrace config requests stack capture, -Sutrace must be enabled */
-		if (!(env.requested_stack_traces & ST_UTRACE)) {
-			for (int i = 0; i < env.utrace_cfg_cnt; i++) {
-				const struct utrace_cfg *cfg = &env.utrace_cfgs[i];
-				for (int j = 0; j < cfg->param_cnt; j++) {
-					if (cfg->params[j].type == UTRACE_PARAM_CAPTURE_STACK) {
-						eprintf("utrace config #%d requests 'stack' capture, but -Sutrace is not enabled\n", i + 1);
-						return -EINVAL;
-					}
-				}
-			}
-		}
-
-		err = utrace_setup(skel);
-		if (err) {
-			eprintf("Failed to setup utrace: %d\n", err);
-			return err;
-		}
-	} else {
-		env.capture_utrace = FALSE;
-		env.requested_stack_traces &= ~ST_UTRACE;
-		bpf_map__set_autocreate(skel->maps.utrace_probe_cfgs, false);
-		bpf_map__set_autocreate(skel->maps.utrace_scratch, false);
+	err = utrace_setup(skel);
+	if (err) {
+		eprintf("Failed to setup utrace: %d\n", err);
+		return err;
 	}
 
 	 /* force RB notification when at least 2.0MB or 25% of ringbuf (whichever is less) is full */


### PR DESCRIPTION
Add 'pid:nvidia-smi' to -U. At setup time, each cfg using it is expanded into one concrete attachment per PID returned by 'nvidia-smi --query-compute-apps=pid'. PIDs whose binary doesn't expose the requested USDT are skipped with a warning; if no attachment succeeds, setup fails. 