### PR TITLE
stats: detect and warn on PMU counter multiplexing

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -142,6 +142,14 @@ enum wprof_stat_id {
 	WSTAT_PYTRACE_EVENT_CNT,
 	WSTAT_PYTRACE_CODE_CACHE_CNT,
 
+	/*
+	 * Per-real-PMU "active" fraction (time_running / time_enabled), stored as a double
+	 * bit-cast into u64. 1.0 means the counter was always counting; lower values indicate
+	 * kernel multiplexing. Index 0 unused; index 1+i is the i-th real PMU (parallel to
+	 * pmu_defs[0..pmu_def_real_cnt-1]).
+	 */
+	WSTAT_PMU_ACTIVE_FRAC,
+
 	__WSTAT_CNT,
 };
 
@@ -172,7 +180,8 @@ struct wprof_stats {
 	u32 pytrace_cnt;
 	u32 ringbuf_sz;
 	u32 task_state_sz;
-	u32 reserved[53];
+	u32 pmu_cnt;
+	u32 reserved[52];
 	u64 stats[];
 } __attribute__((aligned(8)));
 

--- a/src/merge.c
+++ b/src/merge.c
@@ -213,7 +213,7 @@ static void collect_extras(struct persist_state *ps, struct wprof_extra_param **
 }
 
 static int stat_elem_cnt(enum wprof_stat_id id, int rb_cnt, int cpu_cnt,
-			 int prog_cnt, int cuda_cnt, int pytrace_cnt)
+			 int prog_cnt, int cuda_cnt, int pytrace_cnt, int pmu_cnt)
 {
 	switch (id) {
 	case WSTAT_INVALID:
@@ -268,6 +268,9 @@ static int stat_elem_cnt(enum wprof_stat_id id, int rb_cnt, int cpu_cnt,
 	case WSTAT_PYTRACE_EVENT_CNT:
 	case WSTAT_PYTRACE_CODE_CACHE_CNT:
 		return 1 + pytrace_cnt;
+	/* per-PMU (real counters only); index 0 is global/unused */
+	case WSTAT_PMU_ACTIVE_FRAC:
+		return 1 + pmu_cnt;
 	default:
 		eprintf("BUG: unknown stat id %d\n", id);
 		exit(1);
@@ -281,6 +284,7 @@ static struct wprof_stats *prepare_stats(struct persist_state *ps, struct worker
 	int cpu_cnt = env.num_cpus;
 	int cuda_cnt = env.cuda_cnt;
 	int pytrace_cnt = env.pytrace_cnt;
+	int pmu_cnt = env.pmu_real_cnt;
 	int prog_cnt = 0;
 
 	struct bpf_program *p;
@@ -296,7 +300,7 @@ static struct wprof_stats *prepare_stats(struct persist_state *ps, struct worker
 	int offs[__WSTAT_CNT + 1];
 	offs[0] = 0;
 	for (int i = 1; i <= __WSTAT_CNT; i++)
-		offs[i] = offs[i - 1] + stat_elem_cnt(i - 1, rb_cnt, cpu_cnt, prog_cnt, cuda_cnt, pytrace_cnt);
+		offs[i] = offs[i - 1] + stat_elem_cnt(i - 1, rb_cnt, cpu_cnt, prog_cnt, cuda_cnt, pytrace_cnt, pmu_cnt);
 
 	u32 sz = sizeof(struct wprof_stats) + offs[__WSTAT_CNT] * sizeof(u64);
 	struct wprof_stats *s = calloc(1, sz);
@@ -307,6 +311,7 @@ static struct wprof_stats *prepare_stats(struct persist_state *ps, struct worker
 	s->prog_cnt = prog_cnt;
 	s->cuda_cnt = cuda_cnt;
 	s->pytrace_cnt = pytrace_cnt;
+	s->pmu_cnt = pmu_cnt;
 	s->ringbuf_sz = env.ringbuf_sz;
 	s->task_state_sz = env.task_state_sz;
 
@@ -483,6 +488,10 @@ skip_bpf_stats:
 		pytrace_event_cnt[0] += py->ctx->pytrace_event_cnt;
 		pytrace_code_cache_cnt[0] += py->ctx->pytrace_code_cache_cnt;
 	}
+
+	double *pmu_active_frac = (double *)wstats(s, WSTAT_PMU_ACTIVE_FRAC, NULL);
+	for (int i = 0; i < pmu_cnt; i++)
+		pmu_active_frac[1 + i] = env.pmu_reals[i].active_frac;
 
 	return s;
 }

--- a/src/pmu.h
+++ b/src/pmu.h
@@ -51,6 +51,13 @@ struct pmu_event {
 	/* Temporary storage for derived metric parsing (cleared after resolution) */
 	char *num_name;   /* numerator counter name */
 	char *denom_name; /* denominator counter name */
+
+	/*
+	 * time_running / time_enabled captured at session end (real PMUs only).
+	 * 1.0 means the counter was always running; lower values signal kernel
+	 * multiplexing. 0.0 means "not captured" — treat as 1.0.
+	 */
+	double active_frac;
 };
 
 /* Stored format for data persistence (fixed size) */

--- a/src/wprof.c
+++ b/src/wprof.c
@@ -337,6 +337,20 @@ skip_rusage:
 		}
 	}
 
+	double *pmu_active_frac = (double *)wstats(s, WSTAT_PMU_ACTIVE_FRAC, NULL);
+	for (int i = 0; pmu_active_frac && i < s->pmu_cnt; i++) {
+		double active_frac = pmu_active_frac[1 + i];
+
+		/* 0 = not captured, 1.0 = always running; anything else means multiplexed */
+		if (active_frac == 0.0 || active_frac == 1.0)
+			continue;
+
+		struct wevent_pmu_def *def = wevent_pmu_def(env.data_hdr, i);
+		const char *name = wevent_str(env.data_hdr, def->name_stroff);
+		eprintf("!!! PMU counter '%s' was multiplexed by kernel (active %.2f%%), values can be unreliable!\n",
+			name, 100.0 * active_frac);
+	}
+
 skip_error_diag:
 	return;
 }
@@ -430,6 +444,11 @@ static int setup_perf_counters(struct bpf_state *st, int num_cpus)
 			attr.config = ev->config;
 			attr.config1 = ev->config1;
 			attr.config2 = ev->config2;
+			/*
+			 * So we can detect multiplexing at session end by comparing
+			 * time_running against time_enabled per event.
+			 */
+			attr.read_format = PERF_FORMAT_TOTAL_TIME_ENABLED | PERF_FORMAT_TOTAL_TIME_RUNNING;
 
 			int pefd = sys_perf_event_open(&attr, -1, cpu, -1, PERF_FLAG_FD_CLOEXEC);
 			if (pefd < 0) {
@@ -1040,11 +1059,37 @@ static void detach_bpf(struct bpf_state *st, int num_cpus)
 		free(st->perf_timer_fds);
 	}
 	if (st->perf_counter_fds) {
-		for (int i = 0; i < st->perf_counter_fd_cnt; i++) {
-			if (st->perf_counter_fds[i] >= 0) {
-				(void)ioctl(st->perf_counter_fds[i], PERF_EVENT_IOC_DISABLE, 0);
-				close(st->perf_counter_fds[i]);
+		/*
+		 * Disable, read, and close each PMU fd. time_enabled/time_running
+		 * are accumulated per real PMU to compute active_frac, which is
+		 * later persisted via WSTAT_PMU_ACTIVE_FRAC.
+		 */
+		for (int i = 0; i < env.pmu_real_cnt; i++) {
+			u64 tot_enabled = 0, tot_running = 0;
+
+			for (int cpu = 0; cpu < num_cpus; cpu++) {
+				int pe_idx = cpu * env.pmu_real_cnt + i;
+				int fd = st->perf_counter_fds[pe_idx];
+				if (fd < 0)
+					continue;
+
+				(void)ioctl(fd, PERF_EVENT_IOC_DISABLE, 0);
+
+				u64 buf[3] = {}; /* value, time_enabled, time_running */
+				if (read(fd, buf, sizeof(buf)) == sizeof(buf)) {
+					tot_enabled += buf[1];
+					tot_running += buf[2];
+				}
+
+				close(fd);
 			}
+
+			if (tot_enabled == tot_running)
+				env.pmu_reals[i].active_frac = 1.0;
+			else if (tot_enabled == 0)
+				env.pmu_reals[i].active_frac = 0.0;
+			else
+				env.pmu_reals[i].active_frac = tot_running / (double)tot_enabled;
 		}
 		free(st->perf_counter_fds);
 	}


### PR DESCRIPTION
When the kernel runs out of hardware PMU slots and ends up multiplexing counters, the values it reports get scaled and become unreliable. Detect this by asking perf_event_open for PERF_FORMAT_TOTAL_TIME_ENABLED | PERF_FORMAT_TOTAL_TIME_RUNNING, then comparing time_running against time_enabled at session end. Anything less than 1.0 means the kernel was time-slicing the counter.

Persist the per-counter active fraction (time_running / time_enabled, summed across CPUs) as WSTAT_PMU_ACTIVE_FRAC so the warning is also emitted during replay. The fraction is a double bit-cast into a u64 stat slot, and the matching pmu_cnt comes from a previously-reserved field in struct wprof_stats — old data files read back as pmu_cnt=0 and skip the loop entirely, so no version bump is needed.

The disable/read/close passes in detach_bpf are folded into a single per-PMU/per-CPU loop so we can accumulate time_enabled/time_running inline before the fd is closed.