### PR TITLE
pytrace: decouple py-torch from py-trace capture

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -130,7 +130,7 @@ enum wprof_stat_id {
 	WSTAT_CUDA_BUF_CNT,
 	WSTAT_CUDA_DATA_SZ,
 
-	/* PyTrace tracee stats (total + pytrace_cnt entries each) */
+	/* PyTrace tracee stats (total + py_cnt entries each) */
 	WSTAT_PYTRACE_NAME,
 	WSTAT_PYTRACE_STATE,
 	WSTAT_PYTRACE_EVENT_CNT,
@@ -171,7 +171,7 @@ struct wprof_stats {
 	u32 rb_cnt;
 	u32 prog_cnt;
 	u32 cuda_cnt;
-	u32 pytrace_cnt;
+	u32 py_cnt;
 	u32 ringbuf_sz;
 	u32 task_state_sz;
 	u32 pmu_cnt;

--- a/src/env.c
+++ b/src/env.c
@@ -464,13 +464,13 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 		} else if (strcasecmp(arg, "py-trace") == 0) {
 			env.pytrace_discovery = (val == TRUE) ? PYTRACE_DISCOVER_PROC : PYTRACE_DISCOVER_NONE;
 			env.capture_pytrace = val;
-			if (val == FALSE)
-				env.capture_pytorch = FALSE;
 		} else if (strcasecmp(arg, "py-trace=nvidia-smi") == 0 || strcasecmp(arg, "py-trace=nv-smi") == 0) {
-			env.pytrace_discovery = (val == TRUE) ? PYTRACE_DISCOVER_NV_SMI : PYTRACE_DISCOVER_NONE;
+			if (val == FALSE) {
+				eprintf("-f no-py-trace=... feature form doesn't make much sense!\n");
+				return -EINVAL;
+			}
+			env.pytrace_discovery = PYTRACE_DISCOVER_NV_SMI;
 			env.capture_pytrace = val;
-			if (val == FALSE)
-				env.capture_pytorch = FALSE;
 		} else if (strncasecmp(arg, "py-trace=", 9) == 0) {
 			const char *pf_arg = arg + 9;
 			int pid, n;
@@ -492,12 +492,14 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 			}
 			env.capture_pytrace = val;
 		} else if (strcasecmp(arg, "py-torch") == 0) {
-			env.pytrace_discovery = (val == TRUE) ? PYTRACE_DISCOVER_PROC : PYTRACE_DISCOVER_NONE;
-			env.capture_pytrace = val;
+			env.pytorch_discovery = (val == TRUE) ? PYTRACE_DISCOVER_PROC : PYTRACE_DISCOVER_NONE;
 			env.capture_pytorch = val;
 		} else if (strcasecmp(arg, "py-torch=nvidia-smi") == 0 || strcasecmp(arg, "py-torch=nv-smi") == 0) {
-			env.pytrace_discovery = (val == TRUE) ? PYTRACE_DISCOVER_NV_SMI : PYTRACE_DISCOVER_NONE;
-			env.capture_pytrace = val;
+			if (val == FALSE) {
+				eprintf("-f no-py-torch=... feature form doesn't make much sense!\n");
+				return -EINVAL;
+			}
+			env.pytorch_discovery = PYTRACE_DISCOVER_NV_SMI;
 			env.capture_pytorch = val;
 		} else if (strncasecmp(arg, "py-torch=", 9) == 0) {
 			const char *pf_arg = arg + 9;
@@ -509,16 +511,15 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 			}
 
 			if (sscanf(pf_arg, "%d %n", &pid, &n) == 1 && pf_arg[n] == '\0') {
-				err = append_num(&env.pytrace_pids, &env.pytrace_pid_cnt, pf_arg);
+				err = append_num(&env.pytorch_pids, &env.pytorch_pid_cnt, pf_arg);
 				if (err) {
-					eprintf("Failed to record PID '%s' for Python function + torch tracing!\n", pf_arg);
+					eprintf("Failed to record PID '%s' for PyTorch tracing!\n", pf_arg);
 					return err;
 				}
 			} else {
 				eprintf("Use -fpy-torch, -fpy-torch=nv-smi, or -fpy-torch=<PID>!\n");
 				return -EINVAL;
 			}
-			env.capture_pytrace = val;
 			env.capture_pytorch = val;
 		} else if (strcasecmp(arg, "softirq") == 0) {
 			env.capture_softirq = val;

--- a/src/env.h
+++ b/src/env.h
@@ -193,8 +193,13 @@ struct env {
 	int pytrace_pid_cnt;
 	enum pytrace_discover_strategy pytrace_discovery;
 
+	/* EXPERIMENTAL (PyTorch RecordFunction tracing) */
+	int *pytorch_pids;
+	int pytorch_pid_cnt;
+	enum pytrace_discover_strategy pytorch_discovery;
+
 	struct pytrace_tracee *pytraces;
-	int pytrace_cnt;
+	int py_cnt;
 	bool pytraces_deactivated;
 	bool pytraces_retracted;
 

--- a/src/inj.h
+++ b/src/inj.h
@@ -71,8 +71,8 @@ int start_cupti_activities(void);
 void finalize_cupti_activities(void);
 
 struct pytrace_setup_ctx {
-	int dump_fd;
-	int torch_fd;
+	int pytrace_dump_fd;
+	int pytorch_dump_fd;
 	int version_minor;
 	unsigned long *sym_addrs;
 	int sym_addr_cnt;
@@ -83,7 +83,7 @@ struct pytrace_setup_ctx {
 int pytrace_session_setup(struct pytrace_setup_ctx *ctx);
 int pytrace_session_finalize(void);
 
-int torch_profiler_setup(int dump_fd, unsigned long *sym_addrs, int sym_addr_cnt);
-int torch_profiler_teardown(void);
+int pytorch_session_setup(int pytorch_dump_fd, unsigned long *sym_addrs, int sym_addr_cnt);
+int pytorch_session_finalize(void);
 
 #endif /* __INJ_H_ */

--- a/src/inj_common.h
+++ b/src/inj_common.h
@@ -129,7 +129,8 @@ struct inj_msg {
 		struct inj_msg_pytrace_session {
 			long session_timeout_ms;
 			int py_version_minor; /* Python 3.x minor version */
-			bool enable_torch_profiler;
+			bool enable_pytrace;
+			bool enable_pytorch;
 			unsigned long sym_addrs[PYTRACE_SYM_CNT];
 			unsigned long torch_sym_addrs[TORCH_SYM_CNT];
 		} pytrace_session;

--- a/src/inj_lib.c
+++ b/src/inj_lib.c
@@ -518,9 +518,16 @@ static int handle_msg(struct inj_msg *msg, int *fds, int fd_cnt)
 		vlog("Shutdown completed successfully.\n");
 		return -ESHUTDOWN;
 	case INJ_MSG_PYTRACE_SESSION: {
-		if (fd_cnt < 1 || fd_cnt > 2) {
+		/* FDs arrive in (pytrace, torch) order, each present only if enabled. */
+		int want_fds = 0;
+		if (msg->pytrace_session.enable_pytrace)
+			want_fds += 1;
+		if (msg->pytrace_session.enable_pytorch)
+			want_fds += 1;
+		if (fd_cnt != want_fds || fd_cnt < 1) {
 			err = -EPROTO;
-			elog("Received PYTRACE_SESSION command with unexpected FD count %d!\n", fd_cnt);
+			elog("Received PYTRACE_SESSION command with unexpected FD count %d (want %d)!\n",
+			     fd_cnt, want_fds);
 			return err;
 		}
 
@@ -528,11 +535,12 @@ static int handle_msg(struct inj_msg *msg, int *fds, int fd_cnt)
 		int py_ver_minor = msg->pytrace_session.py_version_minor;
 		vlog("Setting up pytrace session (timeout %ldms, Python 3.%d)...\n", sess_timeout_ms, py_ver_minor);
 
-		int dump_fd = fds[0];
-		int torch_fd = (fd_cnt >= 2 && msg->pytrace_session.enable_torch_profiler) ? fds[1] : -1;
+		int fd_idx = 0;
+		int pytrace_dump_fd = msg->pytrace_session.enable_pytrace ? fds[fd_idx++] : -1;
+		int pytorch_dump_fd = msg->pytrace_session.enable_pytorch ? fds[fd_idx++] : -1;
 		struct pytrace_setup_ctx ctx = {
-			.dump_fd = dump_fd,
-			.torch_fd = torch_fd,
+			.pytrace_dump_fd = pytrace_dump_fd,
+			.pytorch_dump_fd = pytorch_dump_fd,
 			.version_minor = py_ver_minor,
 			.sym_addrs = msg->pytrace_session.sym_addrs,
 			.sym_addr_cnt = ARRAY_SIZE(msg->pytrace_session.sym_addrs),

--- a/src/inj_pytrace.c
+++ b/src/inj_pytrace.c
@@ -324,7 +324,7 @@ int pytrace_session_setup(struct pytrace_setup_ctx *ctx)
 	}
 
 	/*
-	 * Validation and torch setup come before any pytrace allocations,
+	 * Validation and pytorch setup come before any pytrace allocations,
 	 * so failures here can return directly without cleanup.
 	 */
 	if (!py_is_initialized()) {
@@ -332,12 +332,21 @@ int pytrace_session_setup(struct pytrace_setup_ctx *ctx)
 		return -ENOENT;
 	}
 
-	if (ctx->torch_fd >= 0) {
-		err = torch_profiler_setup(ctx->torch_fd, ctx->torch_sym_addrs, ctx->torch_sym_addr_cnt);
+	if (ctx->pytorch_dump_fd >= 0) {
+		err = pytorch_session_setup(ctx->pytorch_dump_fd, ctx->torch_sym_addrs, ctx->torch_sym_addr_cnt);
 		if (err) {
-			vlog("Torch profiler setup failed: %d\n", err);
+			vlog("PyTorch tracing setup failed: %d\n", err);
 			return err;
 		}
+	}
+
+	/*
+	 * PyTorch-only session (py-torch without py-trace): no pytrace dump fd, so
+	 * skip Python function tracing (dump + CPython hook) below.
+	 */
+	if (ctx->pytrace_dump_fd < 0) {
+		vlog("pytrace: Python function tracing disabled (PyTorch-only session)\n");
+		return 0;
 	}
 
 	/* Set up dump file */
@@ -347,10 +356,10 @@ int pytrace_session_setup(struct pytrace_setup_ctx *ctx)
 		return -ENOMEM;
 	}
 
-	pytrace_dump = fdopen(ctx->dump_fd, "w");
+	pytrace_dump = fdopen(ctx->pytrace_dump_fd, "w");
 	if (!pytrace_dump) {
 		err = -errno;
-		elog("Failed to create FILE wrapper around pytrace dump FD %d: %d\n", ctx->dump_fd, err);
+		elog("Failed to create FILE wrapper around pytrace dump FD %d: %d\n", ctx->pytrace_dump_fd, err);
 		goto cleanup;
 	}
 	setvbuf(pytrace_dump, NULL, _IOFBF, PYTRACE_DUMP_BUF_SZ);
@@ -413,6 +422,8 @@ int pytrace_session_setup(struct pytrace_setup_ctx *ctx)
 	return 0;
 
 cleanup:
+	/* pytorch may have been set up before this failure; unwind it. */
+	pytorch_session_finalize();
 	pytrace_active = false;
 	if (pytrace_code_cache) {
 		hashmap__free(pytrace_code_cache);
@@ -424,7 +435,7 @@ cleanup:
 		fclose(pytrace_dump);
 		pytrace_dump = NULL;
 	} else {
-		zclose(ctx->dump_fd);
+		zclose(ctx->pytrace_dump_fd);
 	}
 	return err;
 }
@@ -459,15 +470,12 @@ static void pytrace_uninstall_profiler(void)
 	py_gilstate_release(gstate);
 }
 
-int pytrace_session_finalize(void)
+static int pytrace_session_teardown(void)
 {
 	int err = 0;
 
 	if (!pytrace_dump)
 		return 0;
-
-	/* Uninstall torch profiler first (doesn't need GIL) */
-	torch_profiler_teardown();
 
 	/* Uninstall profiler */
 	pytrace_active = false;
@@ -582,4 +590,11 @@ int pytrace_session_finalize(void)
 	pytrace_dump_strs = NULL;
 
 	return 0;
+}
+
+int pytrace_session_finalize(void)
+{
+	/* Finalize pytorch first (doesn't need GIL) */
+	pytorch_session_finalize();
+	return pytrace_session_teardown();
 }

--- a/src/inj_torch_profiler.c
+++ b/src/inj_torch_profiler.c
@@ -464,7 +464,7 @@ static int init_torch_data(FILE *dump)
 
 /* ==================== Public API ==================== */
 
-int torch_profiler_setup(int dump_fd, unsigned long *sym_addrs, int sym_addr_cnt)
+int pytorch_session_setup(int pytorch_dump_fd, unsigned long *sym_addrs, int sym_addr_cnt)
 {
 	int err = 0;
 
@@ -491,10 +491,10 @@ int torch_profiler_setup(int dump_fd, unsigned long *sym_addrs, int sym_addr_cnt
 		return -ENOMEM;
 	}
 
-	torch_dump = fdopen(dump_fd, "w");
+	torch_dump = fdopen(pytorch_dump_fd, "w");
 	if (!torch_dump) {
 		err = -errno;
-		elog("Failed to create FILE wrapper around torch dump FD %d: %d\n", dump_fd, err);
+		elog("Failed to create FILE wrapper around torch dump FD %d: %d\n", pytorch_dump_fd, err);
 		goto cleanup;
 	}
 	setvbuf(torch_dump, NULL, _IOFBF, TORCH_DUMP_BUF_SZ);
@@ -521,12 +521,12 @@ cleanup:
 		fclose(torch_dump);
 		torch_dump = NULL;
 	} else {
-		zclose(dump_fd);
+		zclose(pytorch_dump_fd);
 	}
 	return err;
 }
 
-int torch_profiler_teardown(void)
+int pytorch_session_finalize(void)
 {
 	int err = 0;
 

--- a/src/merge.c
+++ b/src/merge.c
@@ -227,7 +227,7 @@ static void collect_extras(struct persist_state *ps, struct wprof_extra_param **
 }
 
 static int stat_elem_cnt(enum wprof_stat_id id, int rb_cnt, int cpu_cnt,
-			 int prog_cnt, int cuda_cnt, int pytrace_cnt, int pmu_cnt)
+			 int prog_cnt, int cuda_cnt, int py_cnt, int pmu_cnt)
 {
 	switch (id) {
 	case WSTAT_INVALID:
@@ -281,7 +281,7 @@ static int stat_elem_cnt(enum wprof_stat_id id, int rb_cnt, int cpu_cnt,
 	case WSTAT_PYTRACE_STATE:
 	case WSTAT_PYTRACE_EVENT_CNT:
 	case WSTAT_PYTRACE_CODE_CACHE_CNT:
-		return 1 + pytrace_cnt;
+		return 1 + py_cnt;
 	/* per-PMU (real counters only); index 0 is global/unused */
 	case WSTAT_PMU_ACTIVE_FRAC:
 		return 1 + pmu_cnt;
@@ -296,7 +296,7 @@ static struct wprof_stats *prepare_stats(struct persist_state *ps, struct worker
 	int rb_cnt = env.ringbuf_cnt;
 	int cpu_cnt = env.num_cpus;
 	int cuda_cnt = env.cuda_cnt;
-	int pytrace_cnt = env.pytrace_cnt;
+	int py_cnt = env.py_cnt;
 	int pmu_cnt = env.pmu_real_cnt;
 	int prog_cnt = 0;
 
@@ -313,7 +313,7 @@ static struct wprof_stats *prepare_stats(struct persist_state *ps, struct worker
 	int offs[__WSTAT_CNT + 1];
 	offs[0] = 0;
 	for (int i = 1; i <= __WSTAT_CNT; i++)
-		offs[i] = offs[i - 1] + stat_elem_cnt(i - 1, rb_cnt, cpu_cnt, prog_cnt, cuda_cnt, pytrace_cnt, pmu_cnt);
+		offs[i] = offs[i - 1] + stat_elem_cnt(i - 1, rb_cnt, cpu_cnt, prog_cnt, cuda_cnt, py_cnt, pmu_cnt);
 
 	u32 sz = sizeof(struct wprof_stats) + offs[__WSTAT_CNT] * sizeof(u64);
 	struct wprof_stats *s = calloc(1, sz);
@@ -323,7 +323,7 @@ static struct wprof_stats *prepare_stats(struct persist_state *ps, struct worker
 	s->rb_cnt = rb_cnt;
 	s->prog_cnt = prog_cnt;
 	s->cuda_cnt = cuda_cnt;
-	s->pytrace_cnt = pytrace_cnt;
+	s->py_cnt = py_cnt;
 	s->pmu_cnt = pmu_cnt;
 	s->ringbuf_sz = env.ringbuf_sz;
 	s->task_state_sz = env.task_state_sz;
@@ -484,7 +484,7 @@ skip_bpf_stats:
 	u64 *pytrace_event_cnt = wstats(s, WSTAT_PYTRACE_EVENT_CNT, NULL);
 	u64 *pytrace_code_cache_cnt = wstats(s, WSTAT_PYTRACE_CODE_CACHE_CNT, NULL);
 
-	for (int i = 0; i < pytrace_cnt; i++) {
+	for (int i = 0; i < py_cnt; i++) {
 		struct pytrace_tracee *py = &env.pytraces[i];
 
 		/* per-tracee */
@@ -743,10 +743,10 @@ int wprof_persist_data(const char *workdir_name, struct worker_state *workers)
 	 * and fill in both when the torch dump exists.
 	 */
 	int wpytrace_cnt = 0;
-	int wpytrace_cap = env.pytrace_cnt * 2;
+	int wpytrace_cap = env.py_cnt * 2;
 	struct wpytrace_state *wpytraces = calloc(wpytrace_cap, sizeof(*wpytraces));
 
-	for (int i = 0; i < env.pytrace_cnt; i++) {
+	for (int i = 0; i < env.py_cnt; i++) {
 		struct pytrace_tracee *pf = &env.pytraces[i];
 
 		if (pf->state == TRACEE_INACTIVE) {
@@ -761,7 +761,7 @@ int wprof_persist_data(const char *workdir_name, struct worker_state *workers)
 		}
 
 		/* Load pytrace dump and optionally torch dump into wpytraces[] */
-		int dump_fds[] = { pf->dump_fd, pf->torch_dump_fd };
+		int dump_fds[] = { pf->pytrace_dump_fd, pf->pytorch_dump_fd };
 		const char *dump_paths[] = { pf->dump_path, pf->torch_dump_path };
 		const char *dump_labels[] = { "pytrace", "torch" };
 
@@ -1002,7 +1002,7 @@ int wprof_persist_data(const char *workdir_name, struct worker_state *workers)
 		wpf->dump_hdr = NULL;
 		wpf->dump_sz = 0;
 	}
-	for (int i = 0; i < env.pytrace_cnt; i++) {
+	for (int i = 0; i < env.py_cnt; i++) {
 		struct pytrace_tracee *pf = &env.pytraces[i];
 
 		if (!env.keep_workdir && pf->dump_path)
@@ -1015,8 +1015,8 @@ int wprof_persist_data(const char *workdir_name, struct worker_state *workers)
 		free(pf->torch_dump_path);
 		pf->torch_dump_path = NULL;
 
-		zclose(pf->dump_fd);
-		zclose(pf->torch_dump_fd);
+		zclose(pf->pytrace_dump_fd);
+		zclose(pf->pytorch_dump_fd);
 	}
 	free(wpytraces);
 

--- a/src/pytrace.c
+++ b/src/pytrace.c
@@ -44,9 +44,9 @@ static struct pytrace_tracee *add_pytrace_tracee(struct tracee_state *tracee)
 	const struct tracee_info *info = tracee_info(tracee);
 	struct pytrace_tracee *pf;
 
-	env.pytraces = realloc(env.pytraces, (env.pytrace_cnt + 1) * sizeof(*env.pytraces));
+	env.pytraces = realloc(env.pytraces, (env.py_cnt + 1) * sizeof(*env.pytraces));
 
-	pf = &env.pytraces[env.pytrace_cnt];
+	pf = &env.pytraces[env.py_cnt];
 	memset(pf, 0, sizeof(*pf));
 
 	pf->pid = info->pid;
@@ -57,10 +57,10 @@ static struct pytrace_tracee *add_pytrace_tracee(struct tracee_state *tracee)
 	pf->ctx = info->run_ctx;
 
 	pf->log_fd = -1;
-	pf->dump_fd = -1;
-	pf->torch_dump_fd = -1;
+	pf->pytrace_dump_fd = -1;
+	pf->pytorch_dump_fd = -1;
 
-	env.pytrace_cnt++;
+	env.py_cnt++;
 
 	return pf;
 }
@@ -146,7 +146,7 @@ static int try_inject_to_python_process(int pid, int workdir_fd)
 	 * RecordFunction callback in the tracee, which then fires twice per
 	 * op and duplicates every pytorch_entry/exit event.
 	 */
-	for (int i = 0; i < env.pytrace_cnt; i++) {
+	for (int i = 0; i < env.py_cnt; i++) {
 		if (env.pytraces[i].pid == pid)
 			return 0;
 	}
@@ -188,7 +188,7 @@ static int try_inject_to_python_process(int pid, int workdir_fd)
 	log_fd = openat(workdir_fd, log_path, O_RDWR | O_CREAT | O_CLOEXEC, 0644);
 	if (log_fd < 0) {
 		err = -errno;
-		eprintf("Failed to create pytrace tracee %s log file at '%s': %d\n",
+		eprintf("Failed to create Python tracee %s log file at '%s': %d\n",
 			pytrace_proc_str(pid, ns_tid_by_host_tid(pid, pid), proc_name(pid)),
 			log_path, err);
 		return err;
@@ -234,9 +234,9 @@ err_retract:
 	return err;
 }
 
-int pytrace_trace_setup(int workdir_fd)
+static void pytrace_discover_inject(enum pytrace_discover_strategy discovery, int workdir_fd)
 {
-	switch (env.pytrace_discovery) {
+	switch (discovery) {
 	case PYTRACE_DISCOVER_PROC: {
 		int *pidp, pid;
 
@@ -257,48 +257,68 @@ int pytrace_trace_setup(int workdir_fd)
 	case PYTRACE_DISCOVER_NONE:
 		break;
 	default:
-		BUG("unrecognized pytrace discovery strategy %d\n", env.pytrace_discovery);
+		BUG("unrecognized pytrace discovery strategy %d\n", discovery);
 	}
+}
+
+int pytrace_trace_setup(int workdir_fd)
+{
+	/*
+	 * py-trace and py-torch carry independent discovery strategies; run each,
+	 * but skip a duplicate so we don't scan /proc (or re-walk nvidia-smi) twice
+	 * when both sides use the same strategy. try_inject_to_python_process()
+	 * dedups by PID, so any overlap between differing strategies is harmless.
+	 */
+	pytrace_discover_inject(env.pytrace_discovery, workdir_fd);
+	if (env.pytorch_discovery != env.pytrace_discovery)
+		pytrace_discover_inject(env.pytorch_discovery, workdir_fd);
 
 	/* Also try explicitly specified PIDs; try_inject_to_python_process() dedups. */
 	for (int i = 0; i < env.pytrace_pid_cnt; i++)
 		try_inject_to_python_process(env.pytrace_pids[i], workdir_fd);
+	for (int i = 0; i < env.pytorch_pid_cnt; i++)
+		try_inject_to_python_process(env.pytorch_pids[i], workdir_fd);
 
 	return 0;
 }
 
 int pytrace_trace_prepare(int workdir_fd, long sess_timeout_ms)
 {
-	for (int i = 0; i < env.pytrace_cnt; i++) {
+	for (int i = 0; i < env.py_cnt; i++) {
 		struct pytrace_tracee *pf = &env.pytraces[i];
 
+		/* No base pytrace dump for a PyTorch-only session (py-torch without py-trace). */
 		char dump_path[128];
-		snprintf(dump_path, sizeof(dump_path), LIBWPROFINJ_PYTRACE_DUMP_PATH_FMT, getpid(), pf->pid);
+		int pytrace_dump_fd = -1;
+		if (env.capture_pytrace == TRUE) {
+			snprintf(dump_path, sizeof(dump_path), LIBWPROFINJ_PYTRACE_DUMP_PATH_FMT, getpid(), pf->pid);
 
-		int dump_fd = openat(workdir_fd, dump_path, O_RDWR | O_CREAT | O_CLOEXEC, 0644);
-		if (dump_fd < 0) {
-			int err = -errno;
-			eprintf("Failed to create pytrace tracee %s dump file at '%s': %d\n",
-				pytrace_str(pf), dump_path, err);
-			return err;
+			pytrace_dump_fd = openat(workdir_fd, dump_path, O_RDWR | O_CREAT | O_CLOEXEC, 0644);
+			if (pytrace_dump_fd < 0) {
+				int err = -errno;
+				eprintf("Failed to create Python tracee %s dump file at '%s': %d\n",
+					pytrace_str(pf), dump_path, err);
+				return err;
+			}
 		}
 
 		vprintf("Sending PYTRACE_SESSION to tracee #%d (%s), Python 3.%d, timeout %ldms...\n",
 			i, pytrace_str(pf), pf->py_version_minor, sess_timeout_ms);
 
-		int torch_dump_fd = -1;
+		int pytorch_dump_fd = -1;
 		if (env.capture_pytorch == TRUE) {
 			char torch_path[128];
 			snprintf(torch_path, sizeof(torch_path), LIBWPROFINJ_TORCH_DUMP_PATH_FMT, getpid(), pf->pid);
-			torch_dump_fd = openat(workdir_fd, torch_path, O_RDWR | O_CREAT | O_CLOEXEC, 0644);
-			if (torch_dump_fd < 0) {
+			pytorch_dump_fd = openat(workdir_fd, torch_path, O_RDWR | O_CREAT | O_CLOEXEC, 0644);
+			if (pytorch_dump_fd < 0) {
 				int err = -errno;
 				eprintf("Failed to create torch tracee %s dump file at '%s': %d\n",
 					pytrace_str(pf), torch_path, err);
-				close(dump_fd);
+				if (pytrace_dump_fd >= 0)
+					close(pytrace_dump_fd);
 				return err;
 			} else {
-				pf->torch_dump_fd = torch_dump_fd;
+				pf->pytorch_dump_fd = pytorch_dump_fd;
 				pf->torch_dump_path = strdup(torch_path);
 			}
 		}
@@ -308,33 +328,41 @@ int pytrace_trace_prepare(int workdir_fd, long sess_timeout_ms)
 			.pytrace_session = {
 				.session_timeout_ms = sess_timeout_ms,
 				.py_version_minor = pf->py_version_minor,
-				.enable_torch_profiler = (torch_dump_fd >= 0),
+				.enable_pytrace = (pytrace_dump_fd >= 0),
+				.enable_pytorch = (pytorch_dump_fd >= 0),
 			},
 		};
 		memcpy(msg.pytrace_session.sym_addrs, pf->sym_addrs, sizeof(pf->sym_addrs));
 		memcpy(msg.pytrace_session.torch_sym_addrs, pf->torch_sym_addrs, sizeof(pf->torch_sym_addrs));
-		int fds[2] = { dump_fd, torch_dump_fd };
-		int fd_cnt = (torch_dump_fd >= 0) ? 2 : 1;
+		/* Pass only the enabled dump FDs, in (pytrace, torch) order. */
+		int fds[2];
+		int fd_cnt = 0;
+		if (pytrace_dump_fd >= 0)
+			fds[fd_cnt++] = pytrace_dump_fd;
+		if (pytorch_dump_fd >= 0)
+			fds[fd_cnt++] = pytorch_dump_fd;
 		int err = uds_send_data(pf->uds_fd, &msg, sizeof(msg), fds, fd_cnt);
 		if (err < 0) {
-			eprintf("Failed to start pytrace trace session for tracee %s: %d\n",
+			eprintf("Failed to start Python trace session for tracee %s: %d\n",
 				pytrace_str(pf), err);
-			close(dump_fd);
-			if (torch_dump_fd >= 0)
-				close(torch_dump_fd);
+			if (pytrace_dump_fd >= 0)
+				close(pytrace_dump_fd);
+			if (pytorch_dump_fd >= 0)
+				close(pytorch_dump_fd);
 			pf->state = TRACEE_SETUP_FAILED;
 			continue;
 		}
 
-		pf->dump_fd = dump_fd;
-		pf->dump_path = strdup(dump_path);
+		pf->pytrace_dump_fd = pytrace_dump_fd;
+		if (pytrace_dump_fd >= 0)
+			pf->dump_path = strdup(dump_path);
 		pf->state = TRACEE_PENDING;
 	}
 
 	/* Wait for tracees to be ready */
-	vprintf("Waiting for pytrace tracees to be ready...\n");
+	vprintf("Waiting for Python tracees to be ready...\n");
 	u64 start_ts = ktime_now_ns();
-	for (int i = 0; i < env.pytrace_cnt; i++) {
+	for (int i = 0; i < env.py_cnt; i++) {
 		struct pytrace_tracee *pf = &env.pytraces[i];
 
 		if (pf->state != TRACEE_PENDING)
@@ -347,17 +375,17 @@ int pytrace_trace_prepare(int workdir_fd, long sess_timeout_ms)
 
 		switch (pf->ctx->setup_state) {
 		case INJ_SETUP_READY:
-			vprintf("pytrace tracee #%d (%s) is READY!\n", i, pytrace_str(pf));
+			vprintf("Python tracee #%d (%s) is READY!\n", i, pytrace_str(pf));
 			pf->state = TRACEE_ACTIVE;
 			break;
 		case INJ_SETUP_FAILED:
 		default:
 			if (pf->ctx->exit_hint) {
-				vprintf("pytrace tracee #%d (%s) failed: '%s'.\n",
+				vprintf("Python tracee #%d (%s) failed: '%s'.\n",
 					i, pytrace_str(pf), pf->ctx->exit_hint_msg);
 				pf->state = TRACEE_SETUP_FAILED;
 			} else {
-				vprintf("pytrace tracee #%d (%s) TIMED OUT!\n", i, pytrace_str(pf));
+				vprintf("Python tracee #%d (%s) TIMED OUT!\n", i, pytrace_str(pf));
 				pf->state = TRACEE_SETUP_TIMEOUT;
 			}
 			break;
@@ -369,7 +397,7 @@ int pytrace_trace_prepare(int workdir_fd, long sess_timeout_ms)
 
 int pytrace_trace_activate(long sess_start_ts, long sess_end_ts)
 {
-	for (int i = 0; i < env.pytrace_cnt; i++) {
+	for (int i = 0; i < env.py_cnt; i++) {
 		struct pytrace_tracee *pf = &env.pytraces[i];
 
 		if (pf->state != TRACEE_ACTIVE)
@@ -387,7 +415,7 @@ static void dump_tracee_log(struct pytrace_tracee *pf, int idx)
 	if (!(env_log_set & LOG_PYTRACE))
 		return;
 
-	vprintf("PyTrace tracee #%d (%s) LOG (%s) DUMP (LAST STATE %s):\n"
+	vprintf("Python tracee #%d (%s) LOG (%s) DUMP (LAST STATE %s):\n"
 		"=======================================================================================================\n",
 		idx, pytrace_str(pf), pf->log_path, cuda_tracee_state_str(pf->state));
 
@@ -396,7 +424,7 @@ static void dump_tracee_log(struct pytrace_tracee *pf, int idx)
 	FILE *f = fdopen(pf->log_fd, "r");
 	if (!f) {
 		int err = -errno;
-		eprintf("Failed to create FILE wrapper around pytrace tracee #%d (%s) log FD: %d\n",
+		eprintf("Failed to create FILE wrapper around Python tracee #%d (%s) log FD: %d\n",
 			idx, pytrace_str(pf), err);
 		return;
 	}
@@ -417,9 +445,9 @@ void pytrace_trace_deactivate(void)
 	if (env.pytraces_deactivated)
 		return;
 
-	wprintf("Deactivating pytrace trace injections...\n");
+	wprintf("Deactivating Python tracees...\n");
 
-	for (int i = 0; i < env.pytrace_cnt; i++) {
+	for (int i = 0; i < env.py_cnt; i++) {
 		struct pytrace_tracee *pf = &env.pytraces[i];
 
 		if (pf->state == TRACEE_SETUP_FAILED || pf->state == TRACEE_SETUP_TIMEOUT) {
@@ -428,7 +456,7 @@ void pytrace_trace_deactivate(void)
 			continue;
 		}
 
-		vprintf("Signaling pytrace tracee #%d (%s) to exit...\n", i, pytrace_str(pf));
+		vprintf("Signaling Python tracee #%d (%s) to exit...\n", i, pytrace_str(pf));
 
 		struct inj_msg msg = {
 			.kind = INJ_MSG_SHUTDOWN,
@@ -439,7 +467,7 @@ void pytrace_trace_deactivate(void)
 		zclose(pf->uds_fd);
 
 		if (err < 0) {
-			eprintf("Failed to send SHUTDOWN to pytrace tracee #%d (%s): %d\n",
+			eprintf("Failed to send SHUTDOWN to Python tracee #%d (%s): %d\n",
 				i, pytrace_str(pf), err);
 			if (pf->state == TRACEE_ACTIVE)
 				pf->state = TRACEE_SHUTDOWN_FAILED;
@@ -449,9 +477,9 @@ void pytrace_trace_deactivate(void)
 	}
 
 	/* Wait for tracees to shut down */
-	vprintf("Waiting for pytrace tracees to shut down...\n");
+	vprintf("Waiting for Python tracees to shut down...\n");
 	u64 start_ts = ktime_now_ns();
-	for (int i = 0; i < env.pytrace_cnt; i++) {
+	for (int i = 0; i < env.py_cnt; i++) {
 		struct pytrace_tracee *pf = &env.pytraces[i];
 
 		if (pf->state != TRACEE_ACTIVE)
@@ -463,11 +491,11 @@ void pytrace_trace_deactivate(void)
 		}
 
 		if (!pf->ctx->worker_thread_done) {
-			eprintf("pytrace tracee #%d (%s) TIMED OUT DURING TEARDOWN!\n",
+			eprintf("Python tracee #%d (%s) TIMED OUT DURING TEARDOWN!\n",
 				i, pytrace_str(pf));
 			pf->state = TRACEE_SHUTDOWN_TIMEOUT;
 		} else {
-			vprintf("pytrace tracee #%d (%s) shut down cleanly"
+			vprintf("Python tracee #%d (%s) shut down cleanly"
 				" (%ld events, %ld code objects cached).\n",
 				i, pytrace_str(pf),
 				pf->ctx->pytrace_event_cnt, pf->ctx->pytrace_code_cache_cnt);
@@ -485,9 +513,9 @@ void pytrace_trace_retract(void)
 	if (env.pytraces_retracted)
 		return;
 
-	wprintf("Retracting pytrace trace injections...\n");
+	wprintf("Retracting Python tracees...\n");
 
-	for (int i = 0; i < env.pytrace_cnt; i++) {
+	for (int i = 0; i < env.py_cnt; i++) {
 		struct pytrace_tracee *pf = &env.pytraces[i];
 
 		switch (pf->state) {
@@ -498,11 +526,11 @@ void pytrace_trace_retract(void)
 			continue;
 		}
 
-		dprintf(1, "Retracting pytrace tracee #%d (%s)...\n", i, pytrace_str(pf));
+		dprintf(1, "Retracting Python tracee #%d (%s)...\n", i, pytrace_str(pf));
 
 		int err = tracee_retract(pf->tracee);
 		if (err) {
-			eprintf("Retraction for pytrace tracee #%d (%s) FAILED: %d!\n",
+			eprintf("Retraction for Python tracee #%d (%s) FAILED: %d!\n",
 				i, pytrace_str(pf), err);
 		}
 	}
@@ -515,12 +543,12 @@ void pytrace_trace_teardown(void)
 	pytrace_trace_deactivate();
 	pytrace_trace_retract();
 
-	for (int i = 0; i < env.pytrace_cnt; i++) {
+	for (int i = 0; i < env.py_cnt; i++) {
 		struct pytrace_tracee *pf = &env.pytraces[i];
 
 		zclose(pf->uds_fd);
-		zclose(pf->dump_fd);
-		zclose(pf->torch_dump_fd);
+		zclose(pf->pytrace_dump_fd);
+		zclose(pf->pytorch_dump_fd);
 		zclose(pf->log_fd);
 	}
 }

--- a/src/pytrace.h
+++ b/src/pytrace.h
@@ -24,10 +24,10 @@ struct pytrace_tracee {
 	int log_fd;
 	char *log_path;
 
-	int dump_fd;
+	int pytrace_dump_fd;
 	char *dump_path;
 
-	int torch_dump_fd;
+	int pytorch_dump_fd;
 	char *torch_dump_path;
 
 	int py_version_minor;	/* detected Python 3.x version */

--- a/src/wprof.c
+++ b/src/wprof.c
@@ -310,17 +310,17 @@ skip_rusage:
 		}
 	}
 
-	for (int i = 0; i < s->pytrace_cnt; i++) {
+	for (int i = 0; i < s->py_cnt; i++) {
 		u64 state = wstat(s, WSTAT_PYTRACE_STATE, 1 + i);
 		const char *name = wevent_str(env.data_hdr, wstat(s, WSTAT_PYTRACE_NAME, 1 + i));
 
 		if (state != TRACEE_INACTIVE && state != TRACEE_SHUTDOWN_TIMEOUT) {
-			eprintf("!!! PyTrace tracee #%d (%s) encountered problem. Last state: %s\n",
+			eprintf("!!! Python tracee #%d (%s) encountered problem. Last state: %s\n",
 				i, name, cuda_tracee_state_str(state));
 			continue;
 		}
 		if (env.verbose || env.emit_stats) {
-			eprintf("PyTrace tracee #%d (%s): %llu events, %llu code objects cached.\n",
+			eprintf("Python tracee #%d (%s): %llu events, %llu code objects cached.\n",
 				i, name,
 				wstat(s, WSTAT_PYTRACE_EVENT_CNT, 1 + i),
 				wstat(s, WSTAT_PYTRACE_CODE_CACHE_CNT, 1 + i));
@@ -611,10 +611,12 @@ static int setup_bpf(struct bpf_state *st, struct worker_state *workers, int num
 			bpf_program__set_autoload(skel->progs.wprof_cuda_call, true);
 	}
 
-	if (env.pytrace_pid_cnt > 0 || env.pytrace_discovery) {
+	if ((env.capture_pytrace == TRUE || env.capture_pytorch == TRUE) &&
+	    (env.pytrace_pid_cnt > 0 || env.pytorch_pid_cnt > 0 ||
+	     env.pytrace_discovery || env.pytorch_discovery)) {
 		err = pytrace_trace_setup(workdir_fd);
 		if (err) {
-			eprintf("pytrace trace setup failed: %d\n", err);
+			eprintf("Python trace setup failed: %d\n", err);
 			return err;
 		}
 	}
@@ -1776,12 +1778,12 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (env.pytrace_cnt > 0) {
-		wprintf("Preparing pytrace tracees...\n");
+	if (env.py_cnt > 0) {
+		wprintf("Preparing Python tracees...\n");
 		err = pytrace_trace_prepare(workdir_fd,
 					   env.duration_ns / 1000000 + LIBWPROFINJ_SESSION_TIMEOUT_MS);
 		if (err) {
-			eprintf("Failed to prepare pytrace tracing sessions: %d\n", err);
+			eprintf("Failed to prepare Python tracing sessions: %d\n", err);
 			goto cleanup;
 		}
 	}
@@ -1812,11 +1814,11 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (env.pytrace_cnt > 0) {
-		wprintf("Activating pytrace tracees...\n");
+	if (env.py_cnt > 0) {
+		wprintf("Activating Python tracees...\n");
 		err = pytrace_trace_activate(env.sess_start_ts, env.sess_end_ts);
 		if (err) {
-			eprintf("Failed to activate pytrace tracing sessions: %d\n", err);
+			eprintf("Failed to activate Python tracing sessions: %d\n", err);
 			goto cleanup;
 		}
 	}
@@ -1849,7 +1851,7 @@ int main(int argc, char **argv)
 			cuda_trace_retract();
 	}
 
-	if (env.pytrace_cnt > 0)
+	if (env.py_cnt > 0)
 		pytrace_trace_deactivate();
 
 	wprintf("Draining...\n");
@@ -1870,8 +1872,10 @@ int main(int argc, char **argv)
 		env.capture_cuda = false;
 	}
 
-	if (env.pytrace_cnt == 0)
+	if (env.py_cnt == 0) {
 		env.capture_pytrace = false;
+		env.capture_pytorch = false;
+	}
 
 	err = wprof_persist_data(workdir_name, workers);
 	if (err) {
@@ -1885,7 +1889,7 @@ int main(int argc, char **argv)
 	if (env.requested_stack_traces && env.cuda_cnt > 0)
 		cuda_trace_retract();
 
-	if (env.pytrace_cnt > 0)
+	if (env.py_cnt > 0)
 		pytrace_trace_retract();
 
 	{
@@ -1966,7 +1970,7 @@ skip_data_collection:
 cleanup:
 	if (env.cuda_cnt > 0)
 		cuda_trace_teardown();
-	if (env.pytrace_cnt > 0)
+	if (env.py_cnt > 0)
 		pytrace_trace_teardown();
 	cleanup_workers(workers, worker_cnt);
 	detach_bpf(&bpf_state, num_cpus);


### PR DESCRIPTION
py-torch (PyTorch RecordFunction tracing) and py-trace (Python function tracing) were entangled: -f py-torch implicitly enabled py-trace, the two shared one discovery strategy and PID list, and the injected agent always installed the CPython profile hook. There was no way to capture PyTorch ops without also paying for full Python function tracing.

Make them two fully independent capture features:

  - CLI: py-torch sets only capture_pytorch and py-trace sets only capture_pytrace; py-torch no longer implies py-trace. To capture both, request both explicitly (-f py-trace -f py-torch).

  - Discovery: split the shared pytrace_discovery and PID list into per-feature pytrace_discovery/pytrace_pids and pytorch_discovery/pytorch_pids. Injection runs each feature's discovery (skipping a duplicate strategy) and dedups by PID, so overlapping results inject each process once.

  - Injected agent: gate the pytrace dump and CPython profile hook on a pytrace dump fd, so a PyTorch-only session installs only the RecordFunction hook (which already had its own dump/strset/lock); pytorch and pytrace are now torn down independently.

  - Protocol: the PYTRACE_SESSION message carries enable_pytrace and enable_pytorch, and only the enabled dump fds are passed, in (pytrace, pytorch) order.

While here, tidy up surrounding naming and UX:

  - torch_profiler_{setup,teardown} -> pytorch_session_{setup,finalize} (mirroring pytrace_session_{setup,finalize}); factor the pytrace cleanup into pytrace_session_teardown().
  - enable_torch_profiler -> enable_pytorch; dump_fd/torch_dump_fd -> pytrace_dump_fd/pytorch_dump_fd; tracee count pytrace_cnt -> py_cnt (matching cuda_cnt).
  - Reject -f no-py-{trace,torch}=nv-smi (a =value form can't be negated).
  - User-facing progress now says "Python tracees" rather than the internal "pytrace tracees".

Callers relying on -f py-torch to also produce Python function events must now also pass -f py-trace (e.g. the nvidia-smi sweep becomes -f py-trace=nvidia-smi -f py-torch=nvidia-smi).