### PR TITLE
On-cpu tracing flexibility

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -25,6 +25,7 @@ enum cfg_feature_bit {
 	CFG_CAPTURE_HARDIRQ	= 0x200,
 	CFG_NO_SCHED		= 0x400, /* inverted (set = disabled) for backwards compat */
 	CFG_NO_WAKEUP		= 0x800, /* inverted (set = disabled) for backwards compat */
+	CFG_NO_TASK_LIFE	= 0x1000, /* inverted (set = disabled) for backwards compat */
 	CFG_NO_WQ		= 0x2000, /* inverted (set = disabled) for backwards compat */
 };
 

--- a/src/data.h
+++ b/src/data.h
@@ -25,6 +25,7 @@ enum cfg_feature_bit {
 	CFG_CAPTURE_HARDIRQ	= 0x200,
 	CFG_NO_SCHED		= 0x400, /* inverted (set = disabled) for backwards compat */
 	CFG_NO_WAKEUP		= 0x800, /* inverted (set = disabled) for backwards compat */
+	CFG_NO_WQ		= 0x2000, /* inverted (set = disabled) for backwards compat */
 };
 
 struct wprof_data_cfg {

--- a/src/data.h
+++ b/src/data.h
@@ -23,6 +23,8 @@ enum cfg_feature_bit {
 	CFG_CAPTURE_UTRACE	= 0x080,
 	CFG_CAPTURE_SOFTIRQ	= 0x100,
 	CFG_CAPTURE_HARDIRQ	= 0x200,
+	CFG_NO_SCHED		= 0x400, /* inverted (set = disabled) for backwards compat */
+	CFG_NO_WAKEUP		= 0x800, /* inverted (set = disabled) for backwards compat */
 };
 
 struct wprof_data_cfg {

--- a/src/emit.c
+++ b/src/emit.c
@@ -1765,6 +1765,9 @@ static void emit_switch_json(struct worker_state *w, const struct wevent *e, str
 
 static int process_switch(struct worker_state *w, const struct wevent *e)
 {
+	if (!env.capture_sched)
+		return 0;
+
 	struct wprof_data_hdr *hdr = w->dump_hdr;
 	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
 	struct wprof_task next = wevent_resolve_task(hdr, e->swtch.next_task_id);
@@ -1913,6 +1916,9 @@ static void emit_fork_json(struct worker_state *w, const struct wevent *e)
 
 static int process_fork(struct worker_state *w, const struct wevent *e)
 {
+	if (!env.capture_task_life)
+		return 0;
+
 	struct wprof_data_hdr *hdr = w->dump_hdr;
 	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
 	struct wprof_task child = wevent_resolve_task(hdr, e->fork.child_task_id);
@@ -1968,6 +1974,9 @@ static void emit_exec_json(struct worker_state *w, const struct wevent *e)
 
 static int process_exec(struct worker_state *w, const struct wevent *e)
 {
+	if (!env.capture_task_life)
+		return 0;
+
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
 
 	if (!should_trace_task(&task))
@@ -2087,6 +2096,9 @@ static void emit_task_exit_json(struct worker_state *w, const struct wevent *e)
 
 static int process_task_exit(struct worker_state *w, const struct wevent *e)
 {
+	if (!env.capture_task_life)
+		return 0;
+
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
 
 	if (!should_trace_task(&task))
@@ -2162,6 +2174,9 @@ static void emit_wakeup_new(struct worker_state *w, const struct wevent *e)
 
 static int process_wakeup_new(struct worker_state *w, const struct wevent *e)
 {
+	if (!env.capture_wakeup)
+		return 0;
+
 	struct wprof_data_hdr *hdr = w->dump_hdr;
 	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
 
@@ -2218,6 +2233,9 @@ static void emit_waking(struct worker_state *w, const struct wevent *e)
 
 static int process_waking(struct worker_state *w, const struct wevent *e)
 {
+	if (!env.capture_wakeup)
+		return 0;
+
 	struct wprof_data_hdr *hdr = w->dump_hdr;
 	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
 
@@ -2292,7 +2310,7 @@ static void emit_hardirq_exit_json(struct worker_state *w, const struct wevent *
 
 static int process_hardirq_exit(struct worker_state *w, const struct wevent *e)
 {
-	if (env.capture_hardirq != TRUE)
+	if (!env.capture_hardirq)
 		return 0;
 
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
@@ -2367,7 +2385,7 @@ static void emit_softirq_exit_json(struct worker_state *w, const struct wevent *
 
 static int process_softirq_exit(struct worker_state *w, const struct wevent *e)
 {
-	if (env.capture_softirq != TRUE)
+	if (!env.capture_softirq)
 		return 0;
 
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
@@ -2435,6 +2453,9 @@ static void emit_wq_end_json(struct worker_state *w, const struct wevent *e)
 
 static int process_wq_end(struct worker_state *w, const struct wevent *e)
 {
+	if (!env.capture_wq)
+		return 0;
+
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
 
 	if (!should_trace_task(&task))
@@ -2515,6 +2536,9 @@ static void emit_scx_dsq_end_json(struct worker_state *w, const struct wevent *e
 
 static int process_scx_dsq_end(struct worker_state *w, const struct wevent *e)
 {
+	if (!env.capture_scx)
+		return 0;
+
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
 
 	if (!should_trace_task(&task))
@@ -2573,6 +2597,9 @@ static void emit_ipi_send_json(struct worker_state *w, const struct wevent *e)
 
 static int process_ipi_send(struct worker_state *w, const struct wevent *e)
 {
+	if (!env.capture_ipis)
+		return 0;
+
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
 
 	if (!should_trace_task(&task))
@@ -2648,6 +2675,9 @@ static void emit_ipi_exit_json(struct worker_state *w, const struct wevent *e)
 
 static int process_ipi_exit(struct worker_state *w, const struct wevent *e)
 {
+	if (!env.capture_ipis)
+		return 0;
+
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
 
 	if (!should_trace_task(&task))
@@ -2881,7 +2911,7 @@ static void emit_req_event_json(struct worker_state *w, const struct wevent *e)
 
 static int process_req_event(struct worker_state *w, const struct wevent *e)
 {
-	if (env.capture_requests != TRUE)
+	if (!env.capture_requests)
 		return 0;
 
 	struct wprof_data_hdr *hdr = w->dump_hdr;
@@ -3021,7 +3051,7 @@ static void emit_req_task_event_json(struct worker_state *w, const struct wevent
 
 static int process_req_task_event(struct worker_state *w, const struct wevent *e)
 {
-	if (env.capture_requests != TRUE)
+	if (!env.capture_requests)
 		return 0;
 
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
@@ -3235,7 +3265,7 @@ static void emit_cuda_kernel_json(struct worker_state *w, const struct wevent *e
 
 static int process_cuda_kernel(struct worker_state *w, const struct wevent *e)
 {
-	if (env.capture_cuda != TRUE)
+	if (!env.capture_cuda)
 		return 0;
 
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
@@ -3323,7 +3353,7 @@ static void emit_cuda_memcpy_json(struct worker_state *w, const struct wevent *e
 
 static int process_cuda_memcpy(struct worker_state *w, const struct wevent *e)
 {
-	if (env.capture_cuda != TRUE)
+	if (!env.capture_cuda)
 		return 0;
 
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
@@ -3400,7 +3430,7 @@ static void emit_cuda_memset_json(struct worker_state *w, const struct wevent *e
 
 static int process_cuda_memset(struct worker_state *w, const struct wevent *e)
 {
-	if (env.capture_cuda != TRUE)
+	if (!env.capture_cuda)
 		return 0;
 
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
@@ -3495,7 +3525,7 @@ static void emit_cuda_sync_json(struct worker_state *w, const struct wevent *e)
 
 static int process_cuda_sync(struct worker_state *w, const struct wevent *e)
 {
-	if (env.capture_cuda != TRUE)
+	if (!env.capture_cuda)
 		return 0;
 
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
@@ -3609,7 +3639,7 @@ static void emit_cuda_api_json(struct worker_state *w, const struct wevent *e)
 
 static int process_cuda_api(struct worker_state *w, const struct wevent *e)
 {
-	if (env.capture_cuda != TRUE)
+	if (!env.capture_cuda)
 		return 0;
 
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
@@ -3783,7 +3813,7 @@ static void emit_pytrace_event_json(struct worker_state *w, const struct wevent 
 
 static int process_pytrace(struct worker_state *w, const struct wevent *e)
 {
-	if (env.capture_pytrace != TRUE)
+	if (!env.capture_pytrace)
 		return 0;
 
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
@@ -3872,7 +3902,7 @@ static void emit_pytorch_event_json(struct worker_state *w, const struct wevent 
 
 static int process_pytorch(struct worker_state *w, const struct wevent *e)
 {
-	if (env.capture_pytorch != TRUE)
+	if (!env.capture_pytorch)
 		return 0;
 
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
@@ -4183,7 +4213,7 @@ static void emit_utrace_json(struct worker_state *w, const struct wevent *e)
 
 static int process_utrace(struct worker_state *w, const struct wevent *e)
 {
-	if (env.capture_utrace != TRUE)
+	if (!env.capture_utrace)
 		return 0;
 
 	if (!is_ts_in_range(e->ts))
@@ -4203,6 +4233,14 @@ static int process_utrace(struct worker_state *w, const struct wevent *e)
 	return 0;
 }
 
+/*
+ * Event dispatch table. Each handler must early-return when its capture
+ * feature (env.capture_*) is disabled, so that replaying a dump with
+ * -f no-<feature> drops those events from both the Perfetto and JSON output.
+ * The capture flags are resolved to a definite on/off before emit in the
+ * record and replay paths alike. When adding a new event/feature, don't
+ * forget this gate.
+ */
 static handle_event_fn emit_fns[] = {
 	[EV_TIMER] = process_timer,
 	[EV_SWITCH] = process_switch,

--- a/src/emit.c
+++ b/src/emit.c
@@ -1480,6 +1480,7 @@ static struct wpb_ftrace_event *add_ftrace_event(struct worker_state *w, int cpu
 /* EV_SWITCH */
 struct switch_ctx {
 	bool trace_waker, trace_prev, trace_next;
+	bool has_waking;
 	int waker_callstack_id;
 
 	struct task_state *prev_st;
@@ -1606,7 +1607,7 @@ skip_prev_task:
 
 	emit_track_descrs(w, &next);
 
-	if (!e->swtch.waking_ts)
+	if (!s->has_waking)
 		goto skip_waking;
 
 	if (is_ts_in_range(e->swtch.waking_ts)/* && e->swtch.waker_cpu != e->cpu*/) {
@@ -1645,7 +1646,7 @@ skip_waking:
 		if (s->next_offcpu_dur_ns)
 			emit_kv_float(IID_ANNK_OFFCPU_DUR_US, "%.3lf", s->next_offcpu_dur_ns / 1000.0);
 
-		if (e->swtch.waking_ts) {
+		if (s->has_waking) {
 			emit_kv_str(IID_ANNK_WAKER,
 				    iid_str(emit_intern_str(w, waker.comm), waker.comm));
 			if (env.emit_tidpid) {
@@ -1677,7 +1678,7 @@ skip_waking:
 			emit_kv_int(IID_ANNK_SCX_DSQ_ID, e->swtch.next_task_scx_dsq_id);
 		}
 
-		if (e->swtch.waking_ts && is_ts_in_range(e->swtch.waking_ts))
+		if (s->has_waking && is_ts_in_range(e->swtch.waking_ts))
 			emit_flow_id(e->swtch.waking_ts);
 	}
 
@@ -1741,7 +1742,7 @@ static void emit_switch_json(struct worker_state *w, const struct wevent *e, str
 	json_kv_str(j, "prev_state", s->prev_preempted ? "preempted" : "blocked");
 	json_kv_int(j, "prev_prio", e->swtch.prev_prio);
 	json_kv_int(j, "next_prio", e->swtch.next_prio);
-	if (e->swtch.waking_ts) {
+	if (s->has_waking) {
 		json_kv_ts(j, "waking_ts", e->swtch.waking_ts - env.sess_start_ts);
 		json_kv_str(j, "waking_reason", wreason_str(e->swtch.waking_flags));
 		json_task(j, "waker", &waker);
@@ -1773,10 +1774,22 @@ static int process_switch(struct worker_state *w, const struct wevent *e)
 	struct wprof_task next = wevent_resolve_task(hdr, e->swtch.next_task_id);
 	struct wprof_task waker = wevent_resolve_task(hdr, e->swtch.waker_task_id);
 
-	bool has_waking = e->swtch.waking_ts != 0 && is_ts_in_range(e->swtch.waking_ts);
+	bool has_waking = e->swtch.waking_ts != 0;
+
+	/*
+	 * WAKER/WAKEE info is recorded by the sched_waking hook, so it is gated by
+	 * -f wakeup. Preemption (WF_PREEMPTED, recorded by the switch itself) is part
+	 * of context-switch tracking and is left untouched.
+	 */
+	bool waking_is_wakeup = e->swtch.waking_flags == WF_WOKEN ||
+				e->swtch.waking_flags == WF_WOKEN_NEW;
+	if (!env.capture_wakeup && waking_is_wakeup)
+		has_waking = false;
 
 	struct switch_ctx s = {
-		.trace_waker = has_waking && should_trace_task(&waker),
+		.has_waking = has_waking,
+		.trace_waker = has_waking && is_ts_in_range(e->swtch.waking_ts) &&
+			       should_trace_task(&waker),
 		.trace_prev = should_trace_task(&task),
 		.trace_next = should_trace_task(&next),
 	};
@@ -1817,7 +1830,7 @@ static int process_switch(struct worker_state *w, const struct wevent *e)
 		s.next_offcpu_dur_ns = s.next_st->offcpu_ts ? e->ts - s.next_st->offcpu_ts : e->ts - env.sess_start_ts;
 		s.next_st->offcpu_ts = 0;
 
-		if (e->swtch.waking_ts) {
+		if (s.has_waking) {
 			if (e->swtch.waking_flags == WF_PREEMPTED) {
 				/*
 				 * for preemption case, we just accummulate preempted time,
@@ -2039,16 +2052,29 @@ static int process_task_rename(struct worker_state *w, const struct wevent *e)
 {
 	struct wprof_data_hdr *hdr = w->dump_hdr;
 	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
+	struct task_state *st;
 
 	if (!should_trace_task(&task))
 		return 0;
 
+	/* JSON output carries no per-task render state to maintain */
 	if (env.json_path) {
-		emit_task_rename_json(w, e);
+		if (env.capture_task_life)
+			emit_task_rename_json(w, e);
 		return 0;
 	}
 
-	struct task_state *st = task_state(w, &task);
+	if (!env.capture_task_life)
+		goto skip_emit;
+
+	emit_task_rename(w, e);
+
+skip_emit:
+	/*
+	 * Always track the rename so context-switch slices stay correctly named,
+	 * even when the RENAME event itself is suppressed.
+	 */
+	st = task_state(w, &task);
 
 	if (st->rename_ts == 0) {
 		wprof_strlcpy(st->old_comm, task.comm, sizeof(st->old_comm));
@@ -2061,7 +2087,6 @@ static int process_task_rename(struct worker_state *w, const struct wevent *e)
 
 	st->name_iid = emit_intern_str(w, new_comm);
 
-	emit_task_rename(w, e);
 	return 0;
 }
 
@@ -2145,6 +2170,9 @@ static int process_task_free(struct worker_state *w, const struct wevent *e)
 {
 	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
 
+	if (!env.capture_task_life)
+		goto skip_emit;
+
 	if (!should_trace_task(&task))
 		goto skip_emit;
 
@@ -2154,7 +2182,7 @@ static int process_task_free(struct worker_state *w, const struct wevent *e)
 		emit_task_free(w, e);
 
 skip_emit:
-	/* now we should be done with the task */
+	/* always release the render state, even when the FREE event is suppressed */
 	task_state_delete(&task);
 
 	return 0;

--- a/src/emit.c
+++ b/src/emit.c
@@ -2185,12 +2185,35 @@ static int process_wakeup_new(struct worker_state *w, const struct wevent *e)
 static void emit_waking(struct worker_state *w, const struct wevent *e)
 {
 	struct wprof_data_hdr *hdr = w->dump_hdr;
-	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
+	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);	/* the waker */
+	struct wprof_task wakee = wevent_resolve_task(hdr, e->waking.wakee_task_id);
 
 	emit_track_descrs(w, &task);
+	if (should_trace_task(&wakee))
+		emit_track_descrs(w, &wakee);
 
-	struct wprof_task wakee = wevent_resolve_task(hdr, e->waking.wakee_task_id);
-	emit_track_descrs(w, &wakee);
+	/*
+	 * With context switches the WAKER->WAKEE pair is rendered at the wakee's
+	 * switch (see EV_SWITCH), which consumes the waker stack stashed by
+	 * process_waking(). Under -f no-sched that switch never comes, so render a
+	 * standalone WAKER instant on the waker's track here instead.
+	 */
+	if (env.capture_sched)
+		return;
+
+	int tr_id = (env.requested_stack_traces & ST_WAKER) ? e->waking.waker_stack_id : 0;
+
+	emit_instant(trackid_thread(&task), e->ts, IID_NAME_WAKER, IID_CAT_WAKER) {
+		emit_kv_int(IID_ANNK_CPU, e->cpu);
+		if (env.emit_numa)
+			emit_kv_int(IID_ANNK_NUMA_NODE, e->numa_node);
+		emit_kv_str(IID_ANNK_WAKEE, iid_str(emit_intern_str(w, wakee.comm), wakee.comm));
+		if (env.emit_tidpid) {
+			emit_kv_int(IID_ANNK_WAKEE_TID, task_tid(&wakee));
+			emit_kv_int(IID_ANNK_WAKEE_PID, wakee.pid);
+		}
+		emit_callstack(w, tr_id);
+	}
 }
 
 static int process_waking(struct worker_state *w, const struct wevent *e)
@@ -2205,9 +2228,13 @@ static int process_waking(struct worker_state *w, const struct wevent *e)
 	if (tr_id <= 0)
 		return 0;
 
-	struct wprof_task wakee = wevent_resolve_task(hdr, e->waking.wakee_task_id);
-	struct task_state *wakee_st = task_state(w, &wakee);
-	wakee_st->waker_callstack_id = tr_id;
+	/* with context switches, stash the waker stack for the wakee's switch to render */
+	if (env.capture_sched) {
+		struct wprof_task wakee = wevent_resolve_task(hdr, e->waking.wakee_task_id);
+		struct task_state *wakee_st = task_state(w, &wakee);
+
+		wakee_st->waker_callstack_id = tr_id;
+	}
 
 	if (!env.json_path)
 		emit_waking(w, e);
@@ -4224,7 +4251,7 @@ static void emit_header_json(struct worker_state *w)
 	json_kv_int(j, "timer_freq_hz", cfg->timer_freq_hz);
 	for (int i = 0; i < capture_feature_cnt; i++) {
 		const struct capture_feature *f = &capture_features[i];
-		json_kv_bool(j, f->json_key, !!(cfg->capture_features & f->cfg_bit));
+		json_kv_bool(j, f->json_key, cfg_has_feat(cfg->capture_features, f));
 	}
 
 	json_subarr_start(j, "stacks");

--- a/src/env.c
+++ b/src/env.c
@@ -60,6 +60,7 @@ struct env env = {
 	.capture_hardirq = UNSET,
 	.capture_sched = UNSET,
 	.capture_wakeup = UNSET,
+	.capture_wq = UNSET,
 	.emit_sched_view = UNSET,
 	.emit_numa = UNSET,
 	.emit_tidpid = UNSET,
@@ -159,7 +160,7 @@ static const struct argp_option opts[] = {
 	{ "feature", 'f', "FEAT", 0,
 	  "Data capture feature selector. Supported: ipi, req[=PATH|PID], scx, cuda[=nv-smi|all|PID], "
 	  "py-stacks[=nv-smi|PID], py-trace[=nv-smi|PID], py-torch[=nv-smi|PID], "
-	  "softirq, hardirq, irq, sched (on by default), wakeup (on by default). "
+	  "softirq, hardirq, irq, wq, sched (on by default), wakeup (on by default). "
 	  "All features can be prefixed with 'no-' to disable them explicitly." },
 
 	/* trace emitting options */
@@ -553,6 +554,8 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 			env.capture_sched = val;
 		} else if (strcasecmp(arg, "wakeup") == 0) {
 			env.capture_wakeup = val;
+		} else if (strcasecmp(arg, "wq") == 0) {
+			env.capture_wq = val;
 		} else {
 			fprintf(stderr, "Unrecognized data feature '%s!\n", arg);
 			return -EINVAL;

--- a/src/env.c
+++ b/src/env.c
@@ -60,6 +60,7 @@ struct env env = {
 	.capture_hardirq = UNSET,
 	.capture_sched = UNSET,
 	.capture_wakeup = UNSET,
+	.capture_task_life = UNSET,
 	.capture_wq = UNSET,
 	.emit_sched_view = UNSET,
 	.emit_numa = UNSET,
@@ -160,7 +161,7 @@ static const struct argp_option opts[] = {
 	{ "feature", 'f', "FEAT", 0,
 	  "Data capture feature selector. Supported: ipi, req[=PATH|PID], scx, cuda[=nv-smi|all|PID], "
 	  "py-stacks[=nv-smi|PID], py-trace[=nv-smi|PID], py-torch[=nv-smi|PID], "
-	  "softirq, hardirq, irq, wq, sched (on by default), wakeup (on by default). "
+	  "softirq, hardirq, irq, wq, sched (on by default), wakeup (on by default), task-life (on by default). "
 	  "All features can be prefixed with 'no-' to disable them explicitly." },
 
 	/* trace emitting options */
@@ -554,6 +555,8 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 			env.capture_sched = val;
 		} else if (strcasecmp(arg, "wakeup") == 0) {
 			env.capture_wakeup = val;
+		} else if (strcasecmp(arg, "task-life") == 0) {
+			env.capture_task_life = val;
 		} else if (strcasecmp(arg, "wq") == 0) {
 			env.capture_wq = val;
 		} else {

--- a/src/env.c
+++ b/src/env.c
@@ -58,6 +58,8 @@ struct env env = {
 	.capture_utrace = UNSET,
 	.capture_softirq = UNSET,
 	.capture_hardirq = UNSET,
+	.capture_sched = UNSET,
+	.capture_wakeup = UNSET,
 	.emit_sched_view = UNSET,
 	.emit_numa = UNSET,
 	.emit_tidpid = UNSET,
@@ -157,7 +159,8 @@ static const struct argp_option opts[] = {
 	{ "feature", 'f', "FEAT", 0,
 	  "Data capture feature selector. Supported: ipi, req[=PATH|PID], scx, cuda[=nv-smi|all|PID], "
 	  "py-stacks[=nv-smi|PID], py-trace[=nv-smi|PID], py-torch[=nv-smi|PID], "
-	  "softirq, hardirq, irq. All features can be prefixed with 'no-' to disable them explicitly." },
+	  "softirq, hardirq, irq, sched (on by default), wakeup (on by default). "
+	  "All features can be prefixed with 'no-' to disable them explicitly." },
 
 	/* trace emitting options */
 	{ "emit-feature", 'e', "FEAT", 0,
@@ -546,6 +549,10 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 		} else if (strcasecmp(arg, "irq") == 0) {
 			env.capture_softirq = val;
 			env.capture_hardirq = val;
+		} else if (strcasecmp(arg, "sched") == 0) {
+			env.capture_sched = val;
+		} else if (strcasecmp(arg, "wakeup") == 0) {
+			env.capture_wakeup = val;
 		} else {
 			fprintf(stderr, "Unrecognized data feature '%s!\n", arg);
 			return -EINVAL;

--- a/src/env.h
+++ b/src/env.h
@@ -33,6 +33,7 @@
 #define DEFAULT_CAPTURE_HARDIRQ TRUE
 #define DEFAULT_CAPTURE_SCHED TRUE
 #define DEFAULT_CAPTURE_WAKEUP TRUE
+#define DEFAULT_CAPTURE_WQ FALSE
 
 #define DEFAULT_EMIT_NUMA FALSE
 #define DEFAULT_EMIT_TIDPID FALSE
@@ -136,6 +137,7 @@ struct env {
 	enum tristate capture_hardirq;
 	enum tristate capture_sched;	/* context-switch on/off-CPU slices */
 	enum tristate capture_wakeup;	/* waker/wakee tracking */
+	enum tristate capture_wq;	/* kernel workqueue execution */
 
 	/* trace visualization features */
 	enum tristate emit_sched_view;

--- a/src/env.h
+++ b/src/env.h
@@ -31,6 +31,8 @@
 #define DEFAULT_CAPTURE_UTRACE FALSE
 #define DEFAULT_CAPTURE_SOFTIRQ TRUE
 #define DEFAULT_CAPTURE_HARDIRQ TRUE
+#define DEFAULT_CAPTURE_SCHED TRUE
+#define DEFAULT_CAPTURE_WAKEUP TRUE
 
 #define DEFAULT_EMIT_NUMA FALSE
 #define DEFAULT_EMIT_TIDPID FALSE
@@ -132,6 +134,8 @@ struct env {
 	enum tristate capture_utrace;
 	enum tristate capture_softirq;
 	enum tristate capture_hardirq;
+	enum tristate capture_sched;	/* context-switch on/off-CPU slices */
+	enum tristate capture_wakeup;	/* waker/wakee tracking */
 
 	/* trace visualization features */
 	enum tristate emit_sched_view;
@@ -274,10 +278,19 @@ struct capture_feature {
 	enum tristate default_val;
 	size_t env_flag_off;
 	u64 cfg_bit;
+	bool inverted;	/* cfg_bit is set when the feature is DISABLED (default-on features) */
 };
 
 extern const struct capture_feature capture_features[];
 extern const int capture_feature_cnt;
+
+/* whether feature f is recorded as captured in cfg bits, honoring inverted bits */
+static inline bool cfg_has_feat(u64 cfg_bits, const struct capture_feature *f)
+{
+	bool bit = !!(cfg_bits & f->cfg_bit);
+
+	return f->inverted ? !bit : bit;
+}
 
 /*
  * Table of trace emit (-e) options: the WEXTRA_EMIT_* kind they persist as,

--- a/src/env.h
+++ b/src/env.h
@@ -33,6 +33,7 @@
 #define DEFAULT_CAPTURE_HARDIRQ TRUE
 #define DEFAULT_CAPTURE_SCHED TRUE
 #define DEFAULT_CAPTURE_WAKEUP TRUE
+#define DEFAULT_CAPTURE_TASK_LIFE TRUE
 #define DEFAULT_CAPTURE_WQ FALSE
 
 #define DEFAULT_EMIT_NUMA FALSE
@@ -137,6 +138,7 @@ struct env {
 	enum tristate capture_hardirq;
 	enum tristate capture_sched;	/* context-switch on/off-CPU slices */
 	enum tristate capture_wakeup;	/* waker/wakee tracking */
+	enum tristate capture_task_life;	/* task lifetime events (fork/exec/exit/rename) */
 	enum tristate capture_wq;	/* kernel workqueue execution */
 
 	/* trace visualization features */

--- a/src/merge.c
+++ b/src/merge.c
@@ -1183,8 +1183,10 @@ int wprof_persist_data(const char *workdir_name, struct worker_state *workers)
 	for (int i = 0; i < capture_feature_cnt; i++) {
 		const struct capture_feature *f = &capture_features[i];
 		enum tristate *flag = (void *)&env + f->env_flag_off;
+		/* inverted features set the bit when DISABLED (see cfg_feature_captured) */
+		bool set_bit = f->inverted ? (*flag != TRUE) : (*flag == TRUE);
 
-		if (*flag == TRUE)
+		if (set_bit)
 			hdr.cfg.capture_features |= f->cfg_bit;
 		else
 			hdr.cfg.capture_features &= ~f->cfg_bit;

--- a/src/wprof.bpf.c
+++ b/src/wprof.bpf.c
@@ -1144,7 +1144,7 @@ static int handle_workqueue(u64 now_ts, struct task_struct *task, struct work_st
 	return 0;
 }
 
-SEC("tp_btf/workqueue_execute_start")
+SEC("?tp_btf/workqueue_execute_start")
 int BPF_PROG(wprof_wq_exec_start, struct work_struct *work)
 {
 	u64 now_ts = bpf_ktime_get_ns();
@@ -1156,7 +1156,7 @@ int BPF_PROG(wprof_wq_exec_start, struct work_struct *work)
 	return handle_workqueue(now_ts, task, work, true /*start*/);
 }
 
-SEC("tp_btf/workqueue_execute_end")
+SEC("?tp_btf/workqueue_execute_end")
 int BPF_PROG(wprof_wq_exec_end, struct work_struct *work /* , work_func_t function */)
 {
 	u64 now_ts = bpf_ktime_get_ns();

--- a/src/wprof.bpf.c
+++ b/src/wprof.bpf.c
@@ -129,6 +129,7 @@ const volatile u64 rb_submit_threshold_bytes;
 const volatile enum stack_trace_kind requested_stack_traces = ST_ALL;
 const volatile bool capture_scx = true;
 const volatile bool capture_scx_layer_id = false;
+const volatile bool capture_task_life = true;
 
 bool capture_pystacks = false;
 
@@ -859,7 +860,7 @@ int BPF_PROG(wprof_task_wakeup, struct task_struct *p)
 }
 */
 
-SEC("tp_btf/task_rename")
+SEC("?tp_btf/task_rename")
 int BPF_PROG(wprof_task_rename, struct task_struct *task, const char *comm)
 {
 	u64 now_ts = bpf_ktime_get_ns();
@@ -879,7 +880,7 @@ int BPF_PROG(wprof_task_rename, struct task_struct *task, const char *comm)
 }
 
 
-SEC("tp_btf/sched_process_fork")
+SEC("?tp_btf/sched_process_fork")
 int BPF_PROG(wprof_task_fork, struct task_struct *parent, struct task_struct *child)
 {
 	u64 now_ts = bpf_ktime_get_ns();
@@ -895,7 +896,7 @@ int BPF_PROG(wprof_task_fork, struct task_struct *parent, struct task_struct *ch
 	return 0;
 }
 
-SEC("tp_btf/sched_process_exec")
+SEC("?tp_btf/sched_process_exec")
 int BPF_PROG(wprof_task_exec, struct task_struct *p, int old_pid, struct linux_binprm *bprm)
 {
 	u64 now_ts = bpf_ktime_get_ns();
@@ -912,8 +913,22 @@ int BPF_PROG(wprof_task_exec, struct task_struct *p, int old_pid, struct linux_b
 	return 0;
 }
 
-SEC("tp_btf/sched_process_exit")
+SEC("?tp_btf/sched_process_exit")
 int BPF_PROG(wprof_task_exit, struct task_struct *p)
+{
+	u64 now_ts = bpf_ktime_get_ns();
+	struct wprof_event *e;
+
+	if (!should_trace_task(p, now_ts))
+		return 0;
+
+	emit_task_event(e, EV_SZ(task), 0, EV_TASK_EXIT, now_ts, p);
+
+	return 0;
+}
+
+SEC("tp_btf/sched_process_free")
+int BPF_PROG(wprof_task_free, struct task_struct *p)
 {
 	u64 now_ts = bpf_ktime_get_ns();
 	struct task_state *s;
@@ -925,24 +940,14 @@ int BPF_PROG(wprof_task_exit, struct task_struct *p)
 	if (!s)
 		return 0;
 
-	struct wprof_event *e;
-	emit_task_event(e, EV_SZ(task), 0, EV_TASK_EXIT, now_ts, p);
+	/* always free the task_state entry; only emit the event when enabled */
+	if (capture_task_life) {
+		struct wprof_event *e;
+
+		emit_task_event(e, EV_SZ(task), 0, EV_TASK_FREE, now_ts, p);
+	}
 
 	task_state_delete(p->pid);
-
-	return 0;
-}
-
-SEC("tp_btf/sched_process_free")
-int BPF_PROG(wprof_task_free, struct task_struct *p)
-{
-	u64 now_ts = bpf_ktime_get_ns();
-	struct wprof_event *e;
-
-	if (!should_trace_task(p, now_ts))
-		return 0;
-
-	emit_task_event(e, EV_SZ(task), 0, EV_TASK_FREE, now_ts, p);
 
 	return 0;
 }

--- a/src/wprof.bpf.c
+++ b/src/wprof.bpf.c
@@ -638,7 +638,7 @@ int wprof_timer_tick(void *ctx)
 	return 0;
 }
 
-SEC("tp_btf/sched_switch")
+SEC("?tp_btf/sched_switch")
 int BPF_PROG(wprof_task_switch,
 	     bool preempt,
 	     struct task_struct *prev,
@@ -743,7 +743,7 @@ int BPF_PROG(wprof_task_switch,
 	return 0;
 }
 
-SEC("tp_btf/sched_waking")
+SEC("?tp_btf/sched_waking")
 int BPF_PROG(wprof_task_waking, struct task_struct *p)
 {
 	u64 now_ts = bpf_ktime_get_ns();
@@ -793,7 +793,7 @@ skip_emit:
 	return 0;
 }
 
-SEC("tp_btf/sched_wakeup_new")
+SEC("?tp_btf/sched_wakeup_new")
 int BPF_PROG(wprof_task_wakeup_new, struct task_struct *p)
 {
 	u64 now_ts = bpf_ktime_get_ns();

--- a/src/wprof.c
+++ b/src/wprof.c
@@ -89,6 +89,10 @@ const struct capture_feature capture_features[] = {
 	 offsetof(struct env, capture_softirq), CFG_CAPTURE_SOFTIRQ},
 	{"hardirqs", "Hardirqs:", "capture_hardirq", DEFAULT_CAPTURE_HARDIRQ,
 	 offsetof(struct env, capture_hardirq), CFG_CAPTURE_HARDIRQ},
+	{"context switches", "Context switches:", "capture_sched", DEFAULT_CAPTURE_SCHED,
+	 offsetof(struct env, capture_sched), CFG_NO_SCHED, true},
+	{"wakeups", "Wakeups:", "capture_wakeup", DEFAULT_CAPTURE_WAKEUP,
+	 offsetof(struct env, capture_wakeup), CFG_NO_WAKEUP, true},
 };
 
 const int capture_feature_cnt = ARRAY_SIZE(capture_features);
@@ -582,6 +586,14 @@ static int setup_bpf(struct bpf_state *st, struct worker_state *workers, int num
 	if (env.capture_hardirq) {
 		bpf_program__set_autoload(skel->progs.wprof_hardirq_entry, true);
 		bpf_program__set_autoload(skel->progs.wprof_hardirq_exit, true);
+	}
+
+	if (env.capture_sched)
+		bpf_program__set_autoload(skel->progs.wprof_task_switch, true);
+
+	if (env.capture_wakeup) {
+		bpf_program__set_autoload(skel->progs.wprof_task_waking, true);
+		bpf_program__set_autoload(skel->progs.wprof_task_wakeup_new, true);
 	}
 
 	if (env.req_pid_cnt > 0 || env.req_path_cnt > 0 || env.req_global_discovery) {
@@ -1493,7 +1505,7 @@ int main(int argc, char **argv)
 
 			for (int i = 0; i < ARRAY_SIZE(capture_features); i++) {
 				const struct capture_feature *f = &capture_features[i];
-				wprintf("%-*s%s\n", w, f->header, (cfg->capture_features & f->cfg_bit) ? "YES" : "NO");
+				wprintf("%-*s%s\n", w, f->header, cfg_has_feat(cfg->capture_features, f) ? "YES" : "NO");
 			}
 
 			if (dump_hdr->extra_cnt > 0) {
@@ -1648,7 +1660,7 @@ int main(int argc, char **argv)
 		for (int i = 0; i < ARRAY_SIZE(capture_features); i++) {
 			const struct capture_feature *f = &capture_features[i];
 			enum tristate *flag = (void *)&env + f->env_flag_off;
-			bool cfg_flag = !!(cfg->capture_features & f->cfg_bit);
+			bool cfg_flag = cfg_has_feat(cfg->capture_features, f);
 
 			if (*flag == UNSET)
 				*flag = cfg_flag;
@@ -1795,8 +1807,46 @@ int main(int argc, char **argv)
 	env.timer_period_ns = 1000000000ULL / env.timer_freq_hz;
 	if (env.duration_ns == 0)
 		env.duration_ns = DEFAULT_DURATION_MS * 1000000ULL;
+
+	/*
+	 * Resolve --feature sched / wakeup and their dependencies. Off-CPU stacks,
+	 * scx attribution, and the wakee side of a wakeup are all rendered off the
+	 * context switch, so they constrain what is possible under -f no-sched.
+	 * sched is resolved first because the rest keys off it.
+	 */
+	if (env.capture_sched == UNSET)
+		env.capture_sched = DEFAULT_CAPTURE_SCHED;
 	if (env.requested_stack_traces == ST_UNSET)
 		env.requested_stack_traces = DEFAULT_REQUESTED_STACK_TRACES;
+	/*
+	 * wakeup tracking defaults on with sched and off under -f no-sched, but
+	 * -Swaker forces it on (the waker stack is rendered standalone). An explicit
+	 * -f wakeup without -Swaker under -f no-sched has nothing to render -> error.
+	 */
+	if (env.capture_wakeup == UNSET)
+		env.capture_wakeup = env.capture_sched || (env.requested_stack_traces & ST_WAKER);
+
+	if (!env.capture_sched && env.capture_scx == TRUE) {
+		eprintf("-f scx requires context-switch tracking; drop -f no-sched!\n");
+		err = -EINVAL;
+		goto cleanup;
+	}
+	if (!env.capture_sched && (env.requested_stack_traces & ST_OFFCPU)) {
+		eprintf("-Soffcpu requires context-switch tracking; drop -f no-sched!\n");
+		err = -EINVAL;
+		goto cleanup;
+	}
+	if (!env.capture_wakeup && (env.requested_stack_traces & ST_WAKER)) {
+		eprintf("-Swaker requires wakeup tracking; drop -f no-wakeup!\n");
+		err = -EINVAL;
+		goto cleanup;
+	}
+	if (env.capture_wakeup && !env.capture_sched && !(env.requested_stack_traces & ST_WAKER)) {
+		eprintf("-Swaker is required when -f wakeup is requested explicitly!\n");
+		err = -EINVAL;
+		goto cleanup;
+	}
+
 	for (int i = 0; i < ARRAY_SIZE(capture_features); i++) {
 		const struct capture_feature *f = &capture_features[i];
 		enum tristate *flag = (void *)&env + f->env_flag_off;

--- a/src/wprof.c
+++ b/src/wprof.c
@@ -93,6 +93,8 @@ const struct capture_feature capture_features[] = {
 	 offsetof(struct env, capture_sched), CFG_NO_SCHED, true},
 	{"wakeups", "Wakeups:", "capture_wakeup", DEFAULT_CAPTURE_WAKEUP,
 	 offsetof(struct env, capture_wakeup), CFG_NO_WAKEUP, true},
+	{"workqueues", "Workqueues:", "capture_wq", DEFAULT_CAPTURE_WQ,
+	 offsetof(struct env, capture_wq), CFG_NO_WQ, true},
 };
 
 const int capture_feature_cnt = ARRAY_SIZE(capture_features);
@@ -594,6 +596,11 @@ static int setup_bpf(struct bpf_state *st, struct worker_state *workers, int num
 	if (env.capture_wakeup) {
 		bpf_program__set_autoload(skel->progs.wprof_task_waking, true);
 		bpf_program__set_autoload(skel->progs.wprof_task_wakeup_new, true);
+	}
+
+	if (env.capture_wq) {
+		bpf_program__set_autoload(skel->progs.wprof_wq_exec_start, true);
+		bpf_program__set_autoload(skel->progs.wprof_wq_exec_end, true);
 	}
 
 	if (env.req_pid_cnt > 0 || env.req_path_cnt > 0 || env.req_global_discovery) {

--- a/src/wprof.c
+++ b/src/wprof.c
@@ -93,6 +93,8 @@ const struct capture_feature capture_features[] = {
 	 offsetof(struct env, capture_sched), CFG_NO_SCHED, true},
 	{"wakeups", "Wakeups:", "capture_wakeup", DEFAULT_CAPTURE_WAKEUP,
 	 offsetof(struct env, capture_wakeup), CFG_NO_WAKEUP, true},
+	{"task lifetime", "Task lifetime:", "capture_task_life", DEFAULT_CAPTURE_TASK_LIFE,
+	 offsetof(struct env, capture_task_life), CFG_NO_TASK_LIFE, true},
 	{"workqueues", "Workqueues:", "capture_wq", DEFAULT_CAPTURE_WQ,
 	 offsetof(struct env, capture_wq), CFG_NO_WQ, true},
 };
@@ -598,6 +600,17 @@ static int setup_bpf(struct bpf_state *st, struct worker_state *workers, int num
 		bpf_program__set_autoload(skel->progs.wprof_task_wakeup_new, true);
 	}
 
+	/*
+	 * Task lifetime events. wprof_task_free stays always-loaded because it also
+	 * frees the per-task task_states entry; it only emits its event when enabled.
+	 */
+	if (env.capture_task_life) {
+		bpf_program__set_autoload(skel->progs.wprof_task_rename, true);
+		bpf_program__set_autoload(skel->progs.wprof_task_fork, true);
+		bpf_program__set_autoload(skel->progs.wprof_task_exec, true);
+		bpf_program__set_autoload(skel->progs.wprof_task_exit, true);
+	}
+
 	if (env.capture_wq) {
 		bpf_program__set_autoload(skel->progs.wprof_wq_exec_start, true);
 		bpf_program__set_autoload(skel->progs.wprof_wq_exec_end, true);
@@ -731,6 +744,7 @@ static int setup_bpf(struct bpf_state *st, struct worker_state *workers, int num
 	bpf_map__set_autocreate(skel->maps.scx_task_ctxs, skel->rodata->capture_scx_layer_id);
 
 	skel->rodata->capture_scx = env.capture_scx == TRUE;
+	skel->rodata->capture_task_life = env.capture_task_life == TRUE;
 
 	skel->rodata->rb_cnt = env.ringbuf_cnt;
 	bpf_map__set_max_entries(skel->maps.rbs, env.ringbuf_cnt);


### PR DESCRIPTION
Make scheduler/context switch based tracing data optional. Similarly, wakeup/wakee should be optional as well.