### PR TITLE
utrace: add /x and /map(...) arg value render modifiers

### DIFF
--- a/UTRACE.md
+++ b/UTRACE.md
@@ -26,6 +26,9 @@ wprof -U 'usdt:myapp:request_start (arg:0:s32, arg:1:str, path:./myapp, pid:1234
 # raw tracepoint with name template
 wprof -U 'raw_tp:sys_enter (arg:id) | name:"syscall #{id}" |'
 
+# decode an integer arg: map syscall numbers (x86-64) to names
+wprof -U 'raw_tp:sys_enter (arg:id->syscall/map(0=read,1=write,257=openat)) | name:"{syscall}" |'
+
 # function span (entry + exit as a Perfetto slice)
 wprof -U 'uspan:do_work (arg:0->task_id, arg:ret->result, pid:1234, path:./worker)'
 
@@ -85,7 +88,7 @@ key-value pairs in JSON output, and can be used in `name:` templates
 to dynamically label events and spans.
 
 ```
-arg:<index-or-name>[:<type>][->display_name]
+arg:<index-or-name>[:<type>][->display_name][/modifier...]
 ```
 
 **By index:** `arg:0`, `arg:1`, ..., `arg:ret`
@@ -120,6 +123,42 @@ tracepoints) or from ELF USDT note metadata (for USDTs). Falls back to
 - Return probes (`uret:`, `kret:`, `bpfret:`) only support `arg:ret`
 - `arg:ret` is only valid on return and span probes
 - `arg:*` cannot be combined with other arg specs
+
+### Render modifiers
+
+Integer argument values can be reformatted for display with `/`-separated
+modifiers appended to the arg spec (after the optional `->display_name`).
+A modifier is either a bare name or `name(args)`:
+
+| Modifier        | Effect                                                     |
+|-----------------|----------------------------------------------------------|
+| `/x` (`/hex`)   | Render the integer as `0x...` hex instead of decimal      |
+| `/map(K=V,...)` | Map specific values to string labels                     |
+
+For `/map`, each `K` is a key (decimal or `0x` hex) and `V` a label; the
+label runs to the next `,` or the closing `)`. Modifiers **stack**: a value
+is looked up in `/map` first, and on a miss falls back to the numeric format
+(`/x` hex if present, otherwise decimal). They apply everywhere the value is
+shown — `name:` templates, Perfetto annotations, and JSON output.
+
+```
+arg:id->nr/x                              # value shown as 0x...
+arg:id->nr/map(0=read,1=write,257=openat) # mapped, else decimal
+arg:id->nr/x/map(202=futex)               # mapped label, else hex
+```
+
+Example — label every syscall by number via the `sys_enter` raw tracepoint:
+
+```bash
+wprof -U 'raw_tp:sys_enter (arg:id->syscall/map(0=read,1=write,16=ioctl,202=futex,257=openat)) | name:"{syscall}" |'
+```
+
+The syscall numbers above are x86-64 specific (they differ by architecture).
+
+**Supported types:** `/x` applies to integer (`u8`..`s64`) and `ptr` args
+(`ptr` already prints as hex, so `/x` is a no-op there); `/map` applies to
+integer args only. Using a modifier on an unsupported type (e.g. `str`) is a
+parse-time error — or, for args whose type is inferred, an error at setup.
 
 ### Stack trace capture
 
@@ -233,7 +272,9 @@ With `-J`, utrace events appear as:
 Event types: `utrace_instant`, `utrace_entry`, `utrace_exit`.
 
 Argument values are formatted by type: integers as decimal, pointers as
-`"0x..."` hex strings, strings as JSON strings.
+`"0x..."` hex strings, strings as JSON strings. The `/x` and `/map(...)`
+render modifiers (see **Render modifiers**) apply here too — hex values and
+mapped labels are emitted as JSON strings.
 
 ## Type inference
 

--- a/src/emit.c
+++ b/src/emit.c
@@ -4009,6 +4009,31 @@ static s64 read_int_blob(struct wprof_data_hdr *hdr, u32 bloboff, enum utrace_ar
 }
 
 /*
+ * Render a utrace arg value into buf, honoring /x and /map; returns the number
+ * of characters written (snprintf semantics). A mapped value renders as its
+ * label, /x (and ptr) as 0x-hex, strings verbatim, everything else as decimal.
+ * `ref` is the per-arg blob (or string) offset.
+ */
+static int utrace_format_arg(char *buf, size_t buf_sz, struct wprof_data_hdr *hdr, u32 ref,
+			     const struct utrace_param *p)
+{
+	if (p->arg.arg_type == UTRACE_ARG_STR)
+		return snprintf(buf, buf_sz, "%s", wevent_str(hdr, ref));
+
+	s64 val = read_int_blob(hdr, ref, p->arg.arg_type);
+
+	if (p->arg.map_cnt) {
+		const char *label = utrace_arg_map_lookup(p->arg.map, p->arg.map_cnt, (unsigned long long)val);
+		if (label)
+			return snprintf(buf, buf_sz, "%s", label);
+	}
+	if (p->arg.hex || p->arg.arg_type == UTRACE_ARG_PTR)
+		return snprintf(buf, buf_sz, "0x%llx", (unsigned long long)val);
+
+	return snprintf(buf, buf_sz, "%lld", (long long)val);
+}
+
+/*
  * Format a utrace event name using cfg->settings.name_fmt, substituting
  * {arg_name} placeholders with actual argument values. Only entry-side args
  * (non-ret) are available for substitution. Returns length written (like snprintf).
@@ -4029,15 +4054,8 @@ static int format_utrace_name(char *buf, size_t buf_sz, struct wprof_data_hdr *h
 		if (seg->type == UTRACE_FMT_SEG_LIT) {
 			n = snprintf(buf + pos, buf_sz - pos, "%.*s", seg->lit.len, seg->lit.s);
 		} else {
-			if (seg->arg.type == UTRACE_ARG_STR) {
-				n = snprintf(buf + pos, buf_sz - pos, "%s", wevent_str(hdr, arg_refs[seg->arg.arg_idx]));
-			} else if (seg->arg.type == UTRACE_ARG_PTR) {
-				u64 val = read_int_blob(hdr, arg_refs[seg->arg.arg_idx], seg->arg.type);
-				n = snprintf(buf + pos, buf_sz - pos, "0x%llx", (unsigned long long)val);
-			} else {
-				s64 val = read_int_blob(hdr, arg_refs[seg->arg.arg_idx], seg->arg.type);
-				n = snprintf(buf + pos, buf_sz - pos, "%lld", (long long)val);
-			}
+			n = utrace_format_arg(buf + pos, buf_sz - pos, hdr, arg_refs[seg->arg.arg_idx],
+					      seg->arg.param);
 		}
 		if (n > 0)
 			pos += n < (int)(buf_sz - pos) ? n : buf_sz - pos - 1;
@@ -4073,15 +4091,14 @@ static void emit_utrace_args(struct worker_state *w, const struct wevent *e,
 		/* annotation keys are stored by pointer and encoded later, so intern them */
 		struct pb_str name = iid_str(emit_intern_str(w, name_str), name_str);
 
-		if (p->arg.arg_type == UTRACE_ARG_STR) {
-			emit_kv_str(name, wevent_str(hdr, arg_refs[arg_idx]));
-		} else if (p->arg.arg_type == UTRACE_ARG_PTR) {
-			u64 val = read_int_blob(hdr, arg_refs[arg_idx], p->arg.arg_type);
-			emit_kv_str(name, sfmt("0x%llx", (unsigned long long)val));
-		} else {
-			s64 val = read_int_blob(hdr, arg_refs[arg_idx], p->arg.arg_type);
-			emit_kv_int(name, val);
-		}
+		char vbuf[256];
+
+		utrace_format_arg(vbuf, sizeof(vbuf), hdr, arg_refs[arg_idx], p);
+		/*
+		 * val_str is read later in emit_cleanup, after we return, so vbuf would
+		 * be dead by then; sfmt's thread-local ring keeps it alive past this frame
+		 */
+		emit_kv_str(name, sfmt("%s", vbuf));
 		arg_idx++;
 	}
 }
@@ -4220,13 +4237,17 @@ static void emit_utrace_json(struct worker_state *w, const struct wevent *e)
 					name = sfmt("arg%d", p->arg.arg_idx);
 			}
 
-			if (p->arg.arg_type == UTRACE_ARG_STR) {
-				json_kv_str(j, name, wevent_str(hdr, arg_refs[arg_idx]));
-			} else if (p->arg.arg_type == UTRACE_ARG_PTR) {
-				u64 val = read_int_blob(hdr, arg_refs[arg_idx], p->arg.arg_type);
-				json_kv_str(j, name, sfmt("0x%llx", (unsigned long long)val));
-			} else {
+			/*
+			 * Plain integers keep native JSON numeric typing; only /x,
+			 * /map, ptr and str render as (string) text via the formatter.
+			 */
+			if (!p->arg.hex && !p->arg.map_cnt && utrace_arg_is_int(p->arg.arg_type)) {
 				json_kv_int(j, name, read_int_blob(hdr, arg_refs[arg_idx], p->arg.arg_type));
+			} else {
+				char vbuf[256];
+
+				utrace_format_arg(vbuf, sizeof(vbuf), hdr, arg_refs[arg_idx], p);
+				json_kv_str(j, name, vbuf);
 			}
 			arg_idx++;
 		}

--- a/src/strs.h
+++ b/src/strs.h
@@ -89,6 +89,32 @@ static inline struct sview sv_split(struct sview v, const char *delim, struct sv
 	return sv(v.s, pos);
 }
 
+/*
+ * Like sv_split, but only matches delim at the top level — occurrences inside
+ * (...) are skipped (paren depth tracked), so e.g. map(0=a,1=b) survives a ","
+ * split. Like sv_split, *right starts at the delimiter, empty if none found.
+ */
+static inline struct sview sv_split_top(struct sview v, const char *delim, struct sview *right)
+{
+	int dlen = strlen(delim);
+	int depth = 0;
+
+	for (int i = 0; i < v.len; i++) {
+		char c = v.s[i];
+
+		if (c == '(')
+			depth++;
+		else if (c == ')' && depth > 0)
+			depth--;
+		else if (depth == 0 && i + dlen <= v.len && strncmp(v.s + i, delim, dlen) == 0) {
+			*right = sv(v.s + i, v.len - i);
+			return sv(v.s, i);
+		}
+	}
+	*right = sv_empty();
+	return v;
+}
+
 static inline struct sview sv_consume_left(struct sview v, int n)
 {
 	if (n > v.len)

--- a/src/utrace.c
+++ b/src/utrace.c
@@ -791,6 +791,18 @@ static int augment_cfg_args(struct utrace_cfg *cfg, const struct btf *btf)
 
 		if (p->arg.arg_type == UTRACE_ARG_UNKNOWN)
 			p->arg.arg_type = UTRACE_ARG_U64;
+
+		if (p->arg.hex && !utrace_arg_is_int(p->arg.arg_type) &&
+		    p->arg.arg_type != UTRACE_ARG_PTR) {
+			eprintf("utrace: /x supports integer (u8..s64) and ptr args, but '%s' is neither\n",
+				p->arg.name ?: "(unnamed)");
+			return -EINVAL;
+		}
+		if (p->arg.map_cnt && !utrace_arg_is_int(p->arg.arg_type)) {
+			eprintf("utrace: /map supports integer (u8..s64) args, but '%s' is not\n",
+				p->arg.name ?: "(unnamed)");
+			return -EINVAL;
+		}
 	}
 
 	qsort(cfg->params, cfg->param_cnt, sizeof(*cfg->params), cmp_params);

--- a/src/utrace_cfg.c
+++ b/src/utrace_cfg.c
@@ -101,16 +101,109 @@ static const struct {
 	{ "raw_tp:",  UTRACE_RAW_TRACEPOINT },
 };
 
-/* parse "IDX[:TYPE][->NAME]" argument definition without "arg:" prefix */
+static int arg_map_cmp(const void *a, const void *b)
+{
+	const struct utrace_arg_map *x = a, *y = b;
+
+	if (x->key < y->key)
+		return -1;
+	if (x->key > y->key)
+		return 1;
+	return 0;
+}
+
+/* parse "K=V, K=V, ..." int->string map entries (K is int or 0xHEX), sorted by key */
+static int parse_arg_map(struct sview orig, struct sview def, struct utrace_param *p)
+{
+	struct utrace_arg_map *map = NULL;
+	int cnt = 0;
+
+	if (sv_is_empty(sv_trim(def)))
+		return utrace_err(orig, def, "empty map()\n");
+
+	while (!sv_is_empty(def)) {
+		struct sview rest, val;
+		struct sview ent = sv_trim(sv_split_top(def, ",", &rest));
+
+		def = sv_is_empty(rest) ? sv_empty() : sv_consume_left(rest, 1);
+		if (sv_is_empty(ent))
+			continue;
+
+		struct sview key = sv_trim(sv_split(ent, "=", &val));
+		if (sv_is_empty(val))
+			return utrace_err(orig, ent, "map entry must be KEY=LABEL\n");
+		val = sv_trim(sv_consume_left(val, 1));	/* skip '=' */
+		if (sv_is_empty(val))
+			return utrace_err(orig, ent, "empty map label\n");
+
+		long k;
+		if (!sv_as_long(key, &k))
+			return utrace_err(orig, key, "invalid map key (want int or 0xHEX)\n");
+
+		map = realloc(map, (cnt + 1) * sizeof(*map));
+		map[cnt].key = (unsigned long long)k;
+		map[cnt].label = sv_strdup(val);
+		cnt++;
+	}
+
+	qsort(map, cnt, sizeof(*map), arg_map_cmp);
+
+	for (int i = 1; i < cnt; i++) {
+		if (map[i].key == map[i - 1].key)
+			return utrace_err(orig, def, "duplicate map key %lld\n", (long long)map[i].key);
+	}
+
+	p->arg.map = map;
+	p->arg.map_cnt = cnt;
+	return 0;
+}
+
+/*
+ * Apply one render modifier to an arg. Modifiers are generic "name" or
+ * "name(args)" tokens (see parse_arg_param); each interprets its own args.
+ */
+static int parse_arg_modifier(struct sview orig, struct sview mod, struct utrace_param *p)
+{
+	struct sview inner;
+	struct sview name = sv_trim(sv_split(mod, "(", &inner));
+	bool has_inner = !sv_is_empty(inner);
+
+	if (has_inner) {
+		inner = sv_consume_left(inner, 1);	/* skip '(' */
+		if (inner.len == 0 || inner.s[inner.len - 1] != ')')
+			return utrace_err(orig, mod, "unterminated '(' in modifier\n");
+		inner.len--;				/* drop ')' */
+	}
+
+	if (sv_eq(name, "x") || sv_eq(name, "hex")) {
+		if (has_inner)
+			return utrace_err(orig, mod, "'%.*s' takes no arguments\n", name.len, name.s);
+		p->arg.hex = true;
+		return 0;
+	}
+	if (sv_eq(name, "map")) {
+		if (!has_inner)
+			return utrace_err(orig, mod, "'map' requires (KEY=LABEL,...)\n");
+		return parse_arg_map(orig, sv_trim(inner), p);
+	}
+	return utrace_err(orig, name, "unknown arg modifier '%.*s'\n", name.len, name.s);
+}
+
+/* parse "IDX[:TYPE][->NAME][/MOD...]" arg definition without "arg:" prefix */
 static int parse_arg_param(struct sview orig, struct sview def, struct utrace_param *p)
 {
-	struct sview name, arg, arg_type;
+	struct sview name, arg, arg_type, mods;
 	enum utrace_arg_type atype = UTRACE_ARG_UNKNOWN;
 	long idx;
 
 	def = sv_trim(def);
 	if (sv_is_empty(def))
 		return utrace_err(orig, def, "empty arg definition\n");
+
+	struct sview argdef = def;	/* full arg spec, for error highlighting */
+
+	/* peel trailing "/MOD" render modifiers (paren-aware, so map(a,b) is intact) */
+	def = sv_split_top(def, "/", &mods);
 
 	/* split off optional "->name" suffix */
 	def = sv_split(def, "->", &name);
@@ -145,6 +238,39 @@ static int parse_arg_param(struct sview orig, struct sview def, struct utrace_pa
 	p->arg.arg_idx = idx;
 	p->arg.arg_type = atype;
 	p->arg.name = sv_is_empty(name) ? NULL : sv_strdup(name);
+
+	/* render modifiers: "/name" or "/name(args)", e.g. /x, /map(0=a,1=b) */
+	while (!sv_is_empty(mods)) {
+		struct sview rest;
+		struct sview mod = sv_trim(sv_split_top(sv_consume_left(mods, 1), "/", &rest));
+
+		mods = rest;
+		if (sv_is_empty(mod))
+			continue;
+
+		int err = parse_arg_modifier(orig, mod, p);
+		if (err)
+			return err;
+	}
+
+	/*
+	 * /x supports integer and ptr args; /map supports integer args only.
+	 * Validate explicit types here; inferred (UNKNOWN) types are checked after
+	 * type resolution in augment_cfg_args().
+	 */
+	if (atype != UTRACE_ARG_UNKNOWN) {
+		if (p->arg.hex && !utrace_arg_is_int(atype) && atype != UTRACE_ARG_PTR) {
+			return utrace_err(orig, argdef,
+					  "/x supports integer (u8..s64) and ptr args, not '%s'\n",
+					  arg_type_str(atype));
+		}
+		if (p->arg.map_cnt && !utrace_arg_is_int(atype)) {
+			return utrace_err(orig, argdef,
+					  "/map supports integer (u8..s64) args, not '%s'\n",
+					  arg_type_str(atype));
+		}
+	}
+
 	return 0;
 }
 
@@ -156,7 +282,7 @@ static int parse_params(struct sview orig, struct sview def, struct utrace_param
 
 	while (!sv_is_empty(def)) {
 		struct sview rest;
-		struct sview param = sv_split(def, ",", &rest);
+		struct sview param = sv_split_top(def, ",", &rest);
 
 		def = sv_consume_left(rest, 1);
 
@@ -431,7 +557,7 @@ void utrace_compile_fmt(const char *fmt, const struct utrace_param *params, int 
 				segs = realloc(segs, (seg_cnt + 1) * sizeof(*segs));
 				segs[seg_cnt].type = UTRACE_FMT_SEG_ARG;
 				segs[seg_cnt].arg.arg_idx = arg_idx;
-				segs[seg_cnt].arg.type = p->arg.arg_type;
+				segs[seg_cnt].arg.param = p;
 				seg_cnt++;
 				matched = true;
 				break;
@@ -789,6 +915,16 @@ static void format_probe(const struct utrace_cfg *cfg, struct sbuf *sb)
 					sbuf_appendf(sb, ":%s", arg_type_str(p->arg.arg_type));
 				if (p->arg.name)
 					sbuf_appendf(sb, "->%s", p->arg.name);
+				if (p->arg.hex)
+					sbuf_appendf(sb, "/x");
+				if (p->arg.map_cnt) {
+					sbuf_appendf(sb, "/map(");
+					for (int m = 0; m < p->arg.map_cnt; m++) {
+						sbuf_appendf(sb, "%s%lld=%s", m ? "," : "",
+							     (long long)p->arg.map[m].key, p->arg.map[m].label);
+					}
+					sbuf_appendf(sb, ")");
+				}
 				break;
 			default:
 				break;

--- a/src/utrace_cfg.h
+++ b/src/utrace_cfg.h
@@ -78,16 +78,25 @@ struct tp_field {
 	bool is_string;		/* char[] array */
 };
 
+/* int -> string render mapping for an arg (sorted by key, looked up at emit) */
+struct utrace_arg_map {
+	unsigned long long key;
+	char *label;
+};
+
 struct utrace_param {
 	enum utrace_param_type type;
 	union {
 		struct {
 			int arg_idx;			/* 0-based arg index, or UTRACE_ARG_RET */
-			enum utrace_arg_type arg_type; 	/* defaults to UTRACE_ARG_U64 if omitted */
+			enum utrace_arg_type arg_type;	/* defaults to UTRACE_ARG_U64 if omitted */
 			char *name;			/* annotation name, NULL = auto "arg<N>" / "ret" */
 			char *ref_name;			/* name-based arg reference, resolved to arg_idx during augmentation */
 			int tp_byte_off;		/* TP: byte offset into event struct */
 			bool tp_data_loc;		/* TP: __data_loc encoded string field */
+			bool hex;			/* render integer value as 0x%x */
+			struct utrace_arg_map *map;	/* optional int->string map, sorted by key */
+			int map_cnt;
 		} arg;
 		struct {
 			char *path;
@@ -113,7 +122,7 @@ struct utrace_fmt_seg {
 		} lit;
 		struct {
 			int arg_idx;                /* positional index into entry-side arg_refs[] */
-			enum utrace_arg_type type;  /* cached arg type for formatting */
+			const struct utrace_param *param; /* the matched arg's full spec */
 		} arg;
 	};
 };
@@ -207,6 +216,43 @@ static inline bool cfg_is_span(const struct utrace_cfg *cfg)
 		}, **___p = ___legs, *leg = *___p;				\
 		leg;								\
 		leg = *++___p)
+
+/* integer arg types (u8..s64) — the ones /x and /map operate on */
+static inline bool utrace_arg_is_int(enum utrace_arg_type t)
+{
+	switch (t) {
+	case UTRACE_ARG_U8:
+	case UTRACE_ARG_U16:
+	case UTRACE_ARG_U32:
+	case UTRACE_ARG_U64:
+	case UTRACE_ARG_S8:
+	case UTRACE_ARG_S16:
+	case UTRACE_ARG_S32:
+	case UTRACE_ARG_S64:
+		return true;
+	default:
+		return false;
+	}
+}
+
+/* binary-search an arg value in a key-sorted map; returns label or NULL */
+static inline const char *utrace_arg_map_lookup(const struct utrace_arg_map *map, int cnt,
+						unsigned long long key)
+{
+	int lo = 0, hi = cnt - 1;
+
+	while (lo <= hi) {
+		int mid = lo + (hi - lo) / 2;
+
+		if (map[mid].key < key)
+			lo = mid + 1;
+		else if (map[mid].key > key)
+			hi = mid - 1;
+		else
+			return map[mid].label;
+	}
+	return NULL;
+}
 
 void utrace_compile_fmt(const char *fmt, const struct utrace_param *params, int param_cnt,
 			struct utrace_fmt_seg **out_segs, int *out_seg_cnt);


### PR DESCRIPTION
Extend -U arg specs with two render modifiers, appended after the optional "->name": "/x" (alias "/hex") renders an integer or ptr value as 0x-hex, and "/map(K=V,...)" maps an integer value to a string label (keys decimal or 0xHEX; a map miss falls back to /x-hex or decimal). Modifiers apply to the Perfetto annotation, the JSON arg, and {name} format placeholders.

Parsing is paren-aware (new sv_split_top) so commas inside map(...) don't split params or map entries. Maps are stored as a key-sorted array and looked up with bsearch at emit time; duplicate keys are rejected. /x and /map only apply to integer args (ptr also for /x), validated both at parse time (explicit types) and after type resolution (inferred types).

Plain integer args keep native JSON numeric typing; only mapped, hex, ptr and string values render as text. Modifiers round-trip through the persisted cfg text for replay.