### PR TITLE
meta: tag each capture with a UUID

### DIFF
--- a/src/merge.c
+++ b/src/merge.c
@@ -208,16 +208,21 @@ static void collect_extras(struct persist_state *ps, struct wprof_extra_param **
 			add_extra(extras, cnt, f->kind, *flag == TRUE);
 	}
 
-	{
-		char hostname[256];
-		struct utsname uts;
-		if (gethostname(hostname, sizeof(hostname)) == 0)
-			add_extra(extras, cnt, WEXTRA_METADATA, persist_stroff(ps, sfmt("hostname=%s", hostname)));
-		if (uname(&uts) == 0) {
-			add_extra(extras, cnt, WEXTRA_METADATA, persist_stroff(ps, sfmt("kernel=%s", uts.release)));
-			add_extra(extras, cnt, WEXTRA_METADATA, persist_stroff(ps, sfmt("arch=%s", uts.machine)));
-		}
+	/* Persist built-in and user-provided metadata */
+	char hostname[256], uuid[UUID_STR_LEN];
+	struct utsname uts;
+
+	gen_uuid(uuid);
+	add_extra(extras, cnt, WEXTRA_METADATA, persist_stroff(ps, sfmt("uuid=%s", uuid)));
+
+	if (gethostname(hostname, sizeof(hostname)) == 0)
+		add_extra(extras, cnt, WEXTRA_METADATA, persist_stroff(ps, sfmt("hostname=%s", hostname)));
+
+	if (uname(&uts) == 0) {
+		add_extra(extras, cnt, WEXTRA_METADATA, persist_stroff(ps, sfmt("kernel=%s", uts.release)));
+		add_extra(extras, cnt, WEXTRA_METADATA, persist_stroff(ps, sfmt("arch=%s", uts.machine)));
 	}
+
 	for (int i = 0; i < env.metadata_cnt; i++)
 		add_extra(extras, cnt, WEXTRA_METADATA, persist_stroff(ps, env.metadata[i]));
 }

--- a/src/protobuf.c
+++ b/src/protobuf.c
@@ -587,6 +587,27 @@ static void emit_metadata(struct wpb_writer *writer, struct wprof_data_hdr *hdr)
 	 */
 	wpb_emit_system_info(writer, &hostname_str, &kernel_str, &arch_str, num_cpus);
 
+	/*
+	 * Surface our capture UUID as Perfetto's trace_uuid so the UI/trace_processor
+	 * "Trace ID" matches our `uuid=` metadata exactly. trace_processor renders the
+	 * UUID as the big-endian 128-bit value (msb<<64 | lsb), so the first 8 string
+	 * bytes map to msb (big-endian) and the last 8 to lsb (big-endian).
+	 */
+	const char *uuid = meta_lookup(hdr, "uuid");
+	if (uuid) {
+		unsigned int u[16];
+		if (sscanf(uuid, "%2x%2x%2x%2x-%2x%2x-%2x%2x-%2x%2x-%2x%2x%2x%2x%2x%2x",
+			   &u[0], &u[1], &u[2], &u[3], &u[4], &u[5], &u[6], &u[7],
+			   &u[8], &u[9], &u[10], &u[11], &u[12], &u[13], &u[14], &u[15]) == 16) {
+			int64_t msb = 0, lsb = 0;
+			for (int i = 0; i < 8; i++)
+				msb = (msb << 8) | (u[i] & 0xff);
+			for (int i = 0; i < 8; i++)
+				lsb = (lsb << 8) | (u[8 + i] & 0xff);
+			wpb_emit_trace_uuid(writer, msb, lsb);
+		}
+	}
+
 	struct wpb_attr *attrs = calloc(hdr->extra_cnt + 1, sizeof(*attrs));
 	size_t attr_cnt = 0;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -13,6 +13,7 @@
 #include <errno.h>
 #include <sys/syscall.h>
 #include <sys/sysinfo.h>
+#include <sys/random.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
 #include <sys/resource.h>
@@ -579,4 +580,18 @@ void log_printf(int verbosity, const char *fmt, ...)
 	fputs(buf, stderr);
 
 	errno = old_errno;
+}
+
+/* Generate a random RFC 4122 version 4 UUID string (36 chars + NUL). */
+void gen_uuid(char out[UUID_STR_LEN])
+{
+	unsigned char b[16];
+
+	getrandom(b, sizeof(b), 0);
+	b[6] = (b[6] & 0x0f) | 0x40;	/* version 4 */
+	b[8] = (b[8] & 0x3f) | 0x80;	/* variant 1 (RFC 4122) */
+	snprintf(out, UUID_STR_LEN,
+		 "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+		 b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+		 b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15]);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -235,6 +235,10 @@ struct timespec_spec {
 int parse_timespec(const char *arg, struct timespec_spec *out);
 u64 resolve_timespec(const struct timespec_spec *spec, u64 start_ktime_ns);
 
+/* RFC 4122 UUID string: 36 chars (8-4-4-4-12 hex with dashes) + NUL. */
+#define UUID_STR_LEN 37
+void gen_uuid(char out[UUID_STR_LEN]);
+
 /* ARGS PARSING HELPERS */
 int append_str(char ***strs, int *cnt, const char *str);
 int append_str_file(char ***strs, int *cnt, const char *file);

--- a/src/wpb.h
+++ b/src/wpb.h
@@ -191,6 +191,7 @@ void wpb_emit_clock_snapshot(struct wpb_writer *writer, uint64_t realtime_ts);
 void wpb_emit_system_info(struct wpb_writer *writer, const struct wpb_str *hostname,
 			  const struct wpb_str *kernel, const struct wpb_str *arch,
 			  uint32_t num_cpus);
+void wpb_emit_trace_uuid(struct wpb_writer *writer, int64_t msb, int64_t lsb);
 void wpb_emit_trace_attributes(struct wpb_writer *writer, const struct wpb_attr *attrs,
 			       size_t attr_cnt);
 void wpb_emit_interned_data(struct wpb_writer *writer, const struct wpb_interned_data *data);

--- a/src/wpb/build.rs
+++ b/src/wpb/build.rs
@@ -20,6 +20,7 @@ const KEEP_FIELDS: &[(&str, &[&str])] = &[
             "clock_snapshot",
             "system_info",
             "trace_attributes",
+            "trace_uuid",
             "ftrace_events",
             "interned_data",
         ],

--- a/src/wpb/src/lib.rs
+++ b/src/wpb/src/lib.rs
@@ -300,6 +300,15 @@ impl WpbWriter {
         self.emit_packet(&packet)
     }
 
+    fn emit_trace_uuid(&mut self, msb: i64, lsb: i64) -> Result<(), c_int> {
+        let mut packet = base_packet(WPB_SEQ_ID_THREADS);
+        packet.data = Some(trace_packet::Data::TraceUuid(TraceUuid {
+            msb: Some(msb),
+            lsb: Some(lsb),
+        }));
+        self.emit_packet(&packet)
+    }
+
     fn emit_trace_attributes(&mut self, attrs: &[WpbAttr]) -> Result<(), c_int> {
         let mut pb_attrs = Vec::with_capacity(attrs.len());
         for attr in attrs {
@@ -865,6 +874,17 @@ pub unsafe extern "C" fn wpb_emit_system_info(
 
     if let Err(err) = (*writer).emit_system_info(hostname.as_ref(), kernel.as_ref(), arch.as_ref(), num_cpus) {
         wpb_emit_failed("SystemInfo", err);
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wpb_emit_trace_uuid(writer: *mut WpbWriter, msb: i64, lsb: i64) {
+    if writer.is_null() {
+        wpb_emit_failed("TraceUuid", -EINVAL);
+    }
+
+    if let Err(err) = (*writer).emit_trace_uuid(msb, lsb) {
+        wpb_emit_failed("TraceUuid", err);
     }
 }
 


### PR DESCRIPTION
Captures had no stable identifier, making it hard to correlate a .data file (or the .pb traces emitted from it) across hosts, runs, and tools.

Generate a random RFC 4122 v4 UUID once at capture time via getrandom() and persist it as the first metadata entry (uuid=...) in the .data header, next to hostname/kernel/arch. Being baked into the capture, the UUID is stable across every replay/emit from that data.

At emit time, surface the same UUID as Perfetto's TracePacket.trace_uuid so the UI / trace_processor "Trace ID" matches our uuid metadata exactly. trace_processor renders the UUID as the big-endian 128-bit value (msb<<64 | lsb), so the first 8 string bytes map to msb and the last 8 to lsb, both big-endian. This required keeping the trace_uuid field in the wpb proto prune list so prost generates the TraceUuid message.