### PR TITLE
Improve PyTorch injection performance and data completeness

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -219,7 +219,7 @@ WPROF_HDRS := wprof.h utils.h env.h protobuf.h data.h emit.h stacktrace.h topolo
 WPROF_OBJS := $(patsubst %.c,$(OUTPUT)/%.o,$(WPROF_SRCS))
 
 WPROFINJ_SRCS := inj_lib.c inj_strset.c inj_hashmap.c inj_cupti.c inj_pytrace.c inj_torch_profiler.c
-WPROFINJ_HDRS := inj_common.h inj.h wprof_cupti.h pytrace_data.h
+WPROFINJ_HDRS := inj_common.h inj.h wprof_cupti.h pytrace_data.h strcache.h
 WPROFINJ_OBJS := $(patsubst %.c,$(OUTPUT)/%.o,$(WPROFINJ_SRCS))
 
 $(WPROFINJ_OBJS): ALL_CFLAGS += -fPIC

--- a/src/inj.h
+++ b/src/inj.h
@@ -13,6 +13,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <time.h>
+#include <sys/syscall.h>
 
 #include "inj_common.h"
 
@@ -48,6 +49,23 @@ static inline u64 ktime_now_ns()
 	clock_gettime(CLOCK_MONOTONIC, &t);
 
 	return timespec_to_ns(&t);
+}
+
+/*
+ * gettid() is not cached by glibc, so each call is a real syscall. The hot
+ * tracing paths call it per event, so cache it per-thread. New threads start
+ * with freshly zeroed TLS, so the cache re-reads correctly (a real tid is never
+ * 0). We don't support tracing from forked children (they'd inherit and corrupt
+ * the parent's dump fd/stdio buffer regardless), so the post-fork stale-tid case
+ * is moot.
+ */
+static inline u32 inj_gettid(void)
+{
+	static __thread u32 cached_tid;
+
+	if (cached_tid == 0)
+		cached_tid = (u32)syscall(SYS_gettid);
+	return cached_tid;
 }
 
 #define atomic_add(p, v) __atomic_add_fetch((p), (v), __ATOMIC_RELAXED)

--- a/src/inj.h
+++ b/src/inj.h
@@ -37,6 +37,15 @@ void log_printf(int verbosity, const char *fmt, ...);
 
 void *dyn_resolve_sym(const char *sym_name, void *dlopen_handle);
 
+/*
+ * Register/unregister a dump fd while its session is live. On fork(), an atfork
+ * child handler redirects every tracked fd to /dev/null (see libwprofinj_init),
+ * so a forked child -- which we never capture in -- can neither write new events
+ * nor flush its inherited stdio buffers into the parent's capture files.
+ */
+void inj_track_dump_fd(int fd);
+void inj_untrack_dump_fd(int fd);
+
 static inline uint64_t timespec_to_ns(struct timespec *ts)
 {
 	return ts->tv_sec * 1000000000ULL + ts->tv_nsec;

--- a/src/inj_cupti.c
+++ b/src/inj_cupti.c
@@ -187,13 +187,14 @@ static int handle_cupti_record(CUpti_Activity *rec)
 		if (!rec_within_session(start_ts, end_ts, run_ctx->sess_start_ts, run_ctx->sess_end_ts))
 			return -ENODATA;
 
+		int name_off = strset__add_str(cuda_dump_strs, r->name);
 		struct wcuda_event e = {
 			.sz = sizeof(e),
 			.kind = WCK_CUDA_KERNEL,
 			.ts = start_ts,
 			.cuda_kernel = {
 				.end_ts = end_ts,
-				.name_off = strset__add_str(cuda_dump_strs, r->name),
+				.name_off = name_off < 0 ? 0 : name_off,
 				.corr_id = r->correlationId,
 				.device_id = r->deviceId,
 				.stream_id = r->streamId,

--- a/src/inj_lib.c
+++ b/src/inj_lib.c
@@ -46,6 +46,45 @@
 struct inj_setup_ctx *setup_ctx;
 struct inj_run_ctx *run_ctx;
 
+/*
+ * Live dump fds, redirected to /dev/null in a forked child (see inj_atfork_child).
+ * Tracked on the worker thread at session setup/teardown; read in the atfork
+ * child handler. A fork() on an app thread can race a track/untrack, so the
+ * count is published with release / read with acquire and each slot is written
+ * before the count is bumped, so a racing reader only ever sees fully-stored fds.
+ */
+#define INJ_MAX_DUMP_FDS 8
+static int inj_dump_fds[INJ_MAX_DUMP_FDS];
+static int inj_dump_fd_cnt;
+
+void inj_track_dump_fd(int fd)
+{
+	int n = __atomic_load_n(&inj_dump_fd_cnt, __ATOMIC_RELAXED);
+
+	if (fd < 0)
+		return;
+	if (n >= INJ_MAX_DUMP_FDS) {
+		elog("dump fd registry full (%d slots), fd %d not tracked; forked children may corrupt the capture\n",
+		     INJ_MAX_DUMP_FDS, fd);
+		return;
+	}
+	inj_dump_fds[n] = fd;
+	__atomic_store_n(&inj_dump_fd_cnt, n + 1, __ATOMIC_RELEASE);
+}
+
+void inj_untrack_dump_fd(int fd)
+{
+	int n = __atomic_load_n(&inj_dump_fd_cnt, __ATOMIC_RELAXED);
+
+	for (int i = 0; i < n; i++) {
+		if (inj_dump_fds[i] != fd)
+			continue;
+		inj_dump_fds[i] = inj_dump_fds[n - 1];
+		__atomic_store_n(&inj_dump_fd_cnt, n - 1, __ATOMIC_RELEASE);
+		return;
+	}
+}
+
 static int log_fd = -1;
 static int filelog_verbosity = -1;
 
@@ -292,6 +331,8 @@ static int cuda_dump_setup(int dump_fd)
 		goto cleanup;
 	}
 
+	inj_track_dump_fd(dump_fd);
+
 	return 0;
 
 cleanup:
@@ -312,6 +353,8 @@ int cuda_dump_finalize(void)
 
 	if (!cuda_dump)
 		return 0;
+
+	inj_untrack_dump_fd(fileno(cuda_dump));
 
 	fflush(cuda_dump);
 
@@ -896,10 +939,53 @@ static void stop_worker_thread(void)
 	worker_pthread = 0;
 }
 
+/*
+ * Runs in a forked child, before it returns from fork(). We never capture in
+ * forked children: they share the parent's dump fds (one open file description)
+ * and inherit copies of its stdio buffers, so any flush -- the child's own or
+ * libc's flush of the inherited buffer at child exit -- would corrupt the
+ * parent's capture. Manual close-on-fork: redirect every live dump fd to
+ * /dev/null (the parent keeps its own fds, so it is unaffected). Also forget the
+ * worker thread, which is not inherited across fork, so the destructor's
+ * stop_worker_thread() no-ops instead of signaling the parent's worker through
+ * the shared eventfd or hanging on the clone futex. Only async-signal-safe
+ * operations are allowed here. (A child can still inherit torch_lock held and
+ * deadlock on its first RecordFunction op -- child-only, no parent corruption.)
+ */
+static void inj_atfork_child(void)
+{
+	int n = __atomic_load_n(&inj_dump_fd_cnt, __ATOMIC_ACQUIRE);
+	int null_fd = open("/dev/null", O_WRONLY | O_CLOEXEC);
+
+	for (int i = 0; i < n; i++) {
+		if (null_fd >= 0)
+			dup2(null_fd, inj_dump_fds[i]);
+		else
+			close(inj_dump_fds[i]);
+	}
+	if (null_fd >= 0)
+		close(null_fd);
+
+	worker_pthread = 0;
+	inj_tid = -1;
+}
+
+/*
+ * Declared here to avoid pulling in all of <pthread.h>. Called at link time (not
+ * via dlsym) on purpose: glibc ties the handler to this DSO's __dso_handle and
+ * auto-unregisters it when libwprofinj.so is dlclose()'d at retract, so the
+ * handler can't dangle and crash the tracee on a later fork(). The libc_nonshared
+ * stub only needs __register_atfork (in libc), so this adds no libpthread dep.
+ */
+extern int pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*child)(void));
+
 __attribute__((constructor))
 void libwprofinj_init()
 {
 	vlog("======= CONSTRUCTOR ======\n");
+
+	if (pthread_atfork(NULL, NULL, inj_atfork_child) != 0)
+		elog("Failed to register atfork handler; forked children may corrupt the capture\n");
 }
 
 struct inj_setup_ctx *LIBWPROFINJ_SETUP_SYM(struct inj_setup_ctx *ctx)

--- a/src/inj_pytrace.c
+++ b/src/inj_pytrace.c
@@ -379,6 +379,12 @@ int pytrace_session_setup(struct pytrace_setup_ctx *ctx)
 
 	pytrace_active = true;
 
+	/*
+	 * Track before installing the profiler so a fork can't race an untracked fd
+	 * while callbacks are already firing. Untracked again in cleanup on failure.
+	 */
+	inj_track_dump_fd(ctx->pytrace_dump_fd);
+
 	PyGILState_STATE gstate = py_gilstate_ensure();
 
 	PyInterpreterState *interp = py_interp_head();
@@ -425,6 +431,7 @@ cleanup:
 	/* pytorch may have been set up before this failure; unwind it. */
 	pytorch_session_finalize();
 	pytrace_active = false;
+	inj_untrack_dump_fd(ctx->pytrace_dump_fd);
 	if (pytrace_code_cache) {
 		hashmap__free(pytrace_code_cache);
 		pytrace_code_cache = NULL;
@@ -476,6 +483,8 @@ static int pytrace_session_teardown(void)
 
 	if (!pytrace_dump)
 		return 0;
+
+	inj_untrack_dump_fd(fileno(pytrace_dump));
 
 	/* Uninstall profiler */
 	pytrace_active = false;

--- a/src/inj_pytrace.c
+++ b/src/inj_pytrace.c
@@ -197,8 +197,10 @@ static u32 pytrace_cache_code(u64 code_key, PyCodeObject *code)
 
 	idx = pytrace_code_cnt;
 	pytrace_code_keys[idx] = code_key;
-	pytrace_code_entries[idx].func_name_off = strset__add_str(pytrace_dump_strs, func_name);
-	pytrace_code_entries[idx].file_name_off = strset__add_str(pytrace_dump_strs, file_name);
+	int func_off = strset__add_str(pytrace_dump_strs, func_name);
+	int file_off = strset__add_str(pytrace_dump_strs, file_name);
+	pytrace_code_entries[idx].func_name_off = func_off < 0 ? 0 : func_off;
+	pytrace_code_entries[idx].file_name_off = file_off < 0 ? 0 : file_off;
 	pytrace_code_entries[idx].lineno = lineno;
 	pytrace_code_cnt++;
 

--- a/src/inj_pytrace.c
+++ b/src/inj_pytrace.c
@@ -7,7 +7,6 @@
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
-#include <sys/syscall.h>
 
 #include "inj.h"
 #include "inj_common.h"
@@ -222,7 +221,7 @@ static int pytrace_profile_callback(PyObject *obj, PyFrameObject *frame, int wha
 		return 0;
 
 	u64 ts = ktime_now_ns();
-	u32 tid = (u32)syscall(SYS_gettid);
+	u32 tid = inj_gettid();
 
 #ifdef DEBUG
 	/* Count events by (tid, type) for debugging */

--- a/src/inj_torch_profiler.c
+++ b/src/inj_torch_profiler.c
@@ -6,7 +6,6 @@
 #include <string.h>
 #include <errno.h>
 #include <dlfcn.h>
-#include <sys/syscall.h>
 #include <unistd.h>
 #include <pthread.h>
 #include <sys/mman.h>
@@ -89,7 +88,7 @@ static void *rf_start_cb(void *ret_slot, const void *record_fn)
 	}
 
 	u64 ts = ktime_now_ns();
-	u32 tid = (u32)syscall(SYS_gettid);
+	u32 tid = inj_gettid();
 	const char *name = rf_name(record_fn);
 
 	pthread_mutex_lock(&torch_lock);
@@ -124,7 +123,7 @@ static void rf_end_cb(const void *record_fn, void *ctx)
 		return;
 
 	u64 ts = ktime_now_ns();
-	u32 tid = (u32)syscall(SYS_gettid);
+	u32 tid = inj_gettid();
 
 	struct wpytrace_event ev = {
 		.ts = ts,

--- a/src/inj_torch_profiler.c
+++ b/src/inj_torch_profiler.c
@@ -130,13 +130,15 @@ static void rf_end_cb(const void *record_fn, void *ctx)
 
 	u64 ts = ktime_now_ns();
 	u32 tid = inj_gettid();
+	const char *name = rf_name(record_fn);
+	u32 name_off = strcache_intern(&torch_name_cache, name);
 
 	struct wpytrace_event ev = {
 		.ts = ts,
 		.tid = tid,
 		.what = WPYTRACE_PYTORCH_EXIT,
 		.code_key = 0,
-		.rf_name_off = 0,
+		.rf_name_off = name_off,
 	};
 
 	if (fwrite(&ev, sizeof(ev), 1, torch_dump) == 1)

--- a/src/inj_torch_profiler.c
+++ b/src/inj_torch_profiler.c
@@ -13,6 +13,7 @@
 #include "inj.h"
 #include "pytrace_data.h"
 #include "strset.h"
+#include "strcache.h"
 
 /* ==================== RecordFunction hooking ====================
  *
@@ -66,6 +67,14 @@ static u64 rf_callback_handle;
 static bool rf_active;
 
 /*
+ * Lock-free op-name interner (see strcache.h). RecordFunction fires on many
+ * threads, so this keeps the common path -- an op name already interned -- off
+ * torch_lock; only a name's first sighting takes the lock. Backed by
+ * torch_dump_strs / torch_lock, wired up in pytorch_session_setup().
+ */
+static struct strcache torch_name_cache;
+
+/*
  * RecordFunction start callback.
  *
  * C++ signature: std::unique_ptr<ObserverContext> (*)(const RecordFunction&)
@@ -90,10 +99,7 @@ static void *rf_start_cb(void *ret_slot, const void *record_fn)
 	u64 ts = ktime_now_ns();
 	u32 tid = inj_gettid();
 	const char *name = rf_name(record_fn);
-
-	pthread_mutex_lock(&torch_lock);
-	u32 name_off = strset__add_str(torch_dump_strs, name);
-	pthread_mutex_unlock(&torch_lock);
+	u32 name_off = strcache_intern(&torch_name_cache, name);
 
 	struct wpytrace_event ev = {
 		.ts = ts,
@@ -508,6 +514,7 @@ int pytorch_session_setup(int pytorch_dump_fd, unsigned long *sym_addrs, int sym
 
 	torch_active = true;
 	pthread_mutex_init(&torch_lock, NULL);
+	strcache_init(&torch_name_cache, torch_dump_strs, &torch_lock);
 
 	/*
 	 * Track before rf_register so the RecordFunction callback can't fire on an
@@ -542,6 +549,7 @@ int pytorch_session_finalize(void)
 	inj_untrack_dump_fd(fileno(torch_dump));
 
 	rf_unregister();
+	strcache_reset(&torch_name_cache); /* safe: rf_unregister drained all in-flight callbacks */
 	torch_active = false;
 	run_ctx->pytorch_event_cnt = torch_event_cnt;
 	pthread_mutex_destroy(&torch_lock);

--- a/src/inj_torch_profiler.c
+++ b/src/inj_torch_profiler.c
@@ -508,6 +508,13 @@ int pytorch_session_setup(int pytorch_dump_fd, unsigned long *sym_addrs, int sym
 
 	torch_active = true;
 	pthread_mutex_init(&torch_lock, NULL);
+
+	/*
+	 * Track before rf_register so the RecordFunction callback can't fire on an
+	 * untracked fd (a fork in that window would leave the child's fd unprotected).
+	 */
+	inj_track_dump_fd(pytorch_dump_fd);
+
 	rf_register();
 
 	return 0;
@@ -531,6 +538,8 @@ int pytorch_session_finalize(void)
 
 	if (!torch_dump)
 		return 0;
+
+	inj_untrack_dump_fd(fileno(torch_dump));
 
 	rf_unregister();
 	torch_active = false;

--- a/src/strcache.h
+++ b/src/strcache.h
@@ -1,0 +1,147 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright (c) 2026 Meta Platforms, Inc. */
+#ifndef __STRCACHE_H_
+#define __STRCACHE_H_
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "wprof_types.h"
+#include "strset.h"
+
+/*
+ * strcache: a lock-free read cache in front of a strset.
+ *
+ * Interning a string through a strset needs a lock -- strset is not thread-safe,
+ * and even strset__find_str() mutates its buffer. For a read-mostly, write-once
+ * set of strings interned from many threads (e.g. PyTorch RecordFunction op
+ * names, observed on every autograd/interop thread) that lock serializes every
+ * event. strcache fronts the strset with a fixed, append-only, open-addressing
+ * table whose reads are lock-free: hash the string, probe a bounded number of
+ * slots with acquire loads, compare. A previously-seen string (the common case)
+ * returns its offset with no lock; only a string's first sighting falls to the
+ * slow path, which interns it under the caller's lock and publishes the entry
+ * with a release store.
+ *
+ * Sized for the *hot* set, not the whole vocabulary. Real workloads show a small
+ * set of frequent names plus a high-cardinality tail of near-unique names (op
+ * names with embedded shapes/ids), so probe length and load are bounded: the
+ * tail simply stays on the locked path -- caching a seen-once name buys nothing
+ * -- while the hot set is served lock-free, and the table never degrades into a
+ * long scan or grows past its slot count.
+ *
+ * No deletes and no resize, so a lock-free reader never observes a moved or
+ * freed slot; entries are freed once, via strcache_reset().
+ */
+
+#define STRCACHE_CAP       8192			/* slots; power of two */
+#define STRCACHE_MAX_LOAD  (STRCACHE_CAP / 2)	/* cap inserts here to keep probe chains short */
+#define STRCACHE_MAX_PROBE 16			/* beyond this a name stays on the locked path */
+
+struct strcache_entry {
+	u64 hash;	/* full name hash; the primary quick-reject within a probe chain */
+	u32 off;	/* offset within set */
+	u32 len;	/* strlen(str); fills the tail padding and keeps the verify a safe memcmp */
+	char str[];	/* NUL-terminated copy (the interned source may be transient) */
+};
+
+struct strcache {
+	struct strset *set;		/* backing store; offsets are into this */
+	pthread_mutex_t *lock;		/* serializes cold inserts into set */
+	int count;			/* cached entries (touched only under lock) */
+	struct strcache_entry *slots[STRCACHE_CAP]; /* published/read atomically */
+};
+
+/* Initialize an empty cache fronting `set`, serializing cold inserts with `lock`. */
+static inline void strcache_init(struct strcache *cache, struct strset *set, pthread_mutex_t *lock)
+{
+	memset(cache, 0, sizeof(*cache));
+	cache->set = set;
+	cache->lock = lock;
+}
+
+/* h*31 + c (like libbpf str_hash); a single pass also yields the length. */
+static inline u64 strcache_hash(const char *s, u32 *len_out)
+{
+	const char *p;
+	u64 h = 0;
+
+	for (p = s; *p; p++)
+		h = h * 31 + (unsigned char)*p;
+	*len_out = (u32)(p - s);
+	return h;
+}
+
+/* Publish str->off into the table. Caller must hold cache->lock. */
+static inline void strcache_insert(struct strcache *cache, const char *str, u32 len, u64 h, u32 off)
+{
+	u32 idx = h & (STRCACHE_CAP - 1);
+
+	if (cache->count >= STRCACHE_MAX_LOAD)
+		return;
+
+	for (u32 probe = 0; probe < STRCACHE_MAX_PROBE; probe++) {
+		struct strcache_entry *cur = __atomic_load_n(&cache->slots[idx], __ATOMIC_RELAXED);
+		if (cur) {
+			/* same string already cached (e.g. a racing reader interned it)? done */
+			if (cur->hash == h && cur->len == len && memcmp(cur->str, str, len) == 0)
+				return;
+			/* a different name occupies this slot: collision, probe the next one */
+			idx = (idx + 1) & (STRCACHE_CAP - 1);
+			continue;
+		}
+
+		/* empty slot: publish a fresh entry here */
+		struct strcache_entry *e = malloc(sizeof(*e) + len + 1);
+		if (!e)
+			return; /* best-effort cache */
+		e->hash = h;
+		e->off = off;
+		e->len = len;
+		memcpy(e->str, str, len + 1);
+		__atomic_store_n(&cache->slots[idx], e, __ATOMIC_RELEASE);
+		cache->count++;
+		return;
+	}
+	/* probe window full: leave uncached (still correct, just stays on the lock) */
+}
+
+/* Intern str into cache->set, returning its offset; lock-free on the warm path. */
+static inline u32 strcache_intern(struct strcache *cache, const char *str)
+{
+	u32 len;
+	u64 h = strcache_hash(str, &len);
+	u32 idx = h & (STRCACHE_CAP - 1);
+
+	for (u32 probe = 0; probe < STRCACHE_MAX_PROBE; probe++) {
+		struct strcache_entry *e = __atomic_load_n(&cache->slots[idx], __ATOMIC_ACQUIRE);
+		if (!e)
+			break; /* first empty slot in the chain => not cached */
+		if (e->hash == h && e->len == len && memcmp(e->str, str, len) == 0)
+			return e->off;
+		idx = (idx + 1) & (STRCACHE_CAP - 1);
+	}
+
+	/*
+	 * cold: intern under the lock. strset__add_str returns < 0 only when the
+	 * strset is full -- record offset 0 (the "" sentinel), not a garbage offset.
+	 */
+	pthread_mutex_lock(cache->lock);
+	int off = strset__add_str(cache->set, str);
+	strcache_insert(cache, str, len, h, off < 0 ? 0 : off);
+	pthread_mutex_unlock(cache->lock);
+	return off < 0 ? 0 : off;
+}
+
+/* Free all entries. Caller must ensure no concurrent intern (e.g. callbacks drained). */
+static inline void strcache_reset(struct strcache *cache)
+{
+	for (u32 i = 0; i < STRCACHE_CAP; i++) {
+		free(cache->slots[i]);
+		cache->slots[i] = NULL;
+	}
+	cache->count = 0;
+}
+
+#endif /* __STRCACHE_H_ */


### PR DESCRIPTION
1. Add lockless global string cache for quick lookup and resolution of repeat string references.
2. Record operation name for exit events for PyTorch
3. Avoid unnecessary calls to gettid() syscalls
4. Ensure forked child process while libwprofinj.so is active doesn't corrupt data.