### PR TITLE
ci: bump GitHub Actions to Node 24 (v5) releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           sudo apt-get install -y cargo llvm libelf-dev zlib1g-dev libzstd-dev protobuf-compiler
 
       - name: Checkout wprof code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           path: 'wprof'
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: wprof-${{ matrix.arch }}-${{ matrix.static && 'static' || 'dynamic' }}${{ matrix.nolto && '-nolto' || '' }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get install -y cargo llvm libelf-dev zlib1g-dev libzstd-dev
 
       - name: Checkout wprof code
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           path: 'wprof'
@@ -53,7 +53,7 @@ jobs:
               grep -q 'not a dynamic executable'
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ format('wprof_{0}', matrix.arch) }}
           path: wprof/src/wprof
@@ -66,7 +66,7 @@ jobs:
       contents: write
     steps:
       - name: Download artifacts from build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
 
       - name: Rename binaries and compress
         run: |
@@ -78,7 +78,7 @@ jobs:
           sha256sum "${archive_arm64}" > "${archive_arm64}.sha256sum"
 
       - name: Checkout wprof and submodules code
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           path: 'wprof'


### PR DESCRIPTION
actions/checkout, actions/upload-artifact and actions/download-artifact targeted Node 20 (checkout SHA-pinned to v4.1.0/v3.5.0, artifacts on v4), which GitHub now forces onto Node 24 with a deprecation warning. Move them to the v5 releases that run on Node 24 natively.