### PR TITLE
build: drop -Werror=format-security for bootstrap bpftool

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -122,11 +122,13 @@ $(LIBBPF_OBJ): $(wildcard $(LIBBPF_SRC)/*.[ch] $(LIBBPF_SRC)/Makefile) | $(OUTPU
 		    EXTRA_CFLAGS="-g -O$(if $(DEBUG),0,2) -Wno-sign-compare"			\
 		    install
 
-# Build bpftool
+# Build bpftool.
+# bpftool filters -Wall/-Wformat* (but not -Werror=format-security) out of the flags it
+# hands to its bootstrap libbpf build, so drop it here: gcc errors out on the leftover.
 $(BPFTOOL): | $(BPFTOOL_OUTPUT)
 	$(call msg,BPFTOOL,$@)
 	$(Q) [ -d ../bpftool/src ] || git submodule update --init --recursive
-	$(Q)CFLAGS= HOST_EXTRACFLAGS="$(CFLAGS) -Wno-sign-compare" 				\
+	$(Q)CFLAGS= HOST_EXTRACFLAGS="$(filter-out -Werror=format-security,$(CFLAGS)) -Wno-sign-compare" \
 		$(MAKE) ARCH= CROSS_COMPILE=							\
 			BPF_DIR=$(LIBBPF_SRC) OUTPUT=$(BPFTOOL_OUTPUT_ABS)/			\
 			-C $(BPFTOOL_SRC) bootstrap


### PR DESCRIPTION
bpftool filters -W, -Wall, -Wextra and -Wformat* out of the flags it hands down to its bootstrap libbpf build. -Werror=format-security doesn't match -Wformat%, so it survives the filter while -Wall does not, and gcc rejects the leftover:

  cc1: error: '-Wformat-security' ignored without '-Wformat'

That breaks the build whenever distro hardening flags reach us through CFLAGS, e.g. RPM's build flags on CentOS/Fedora. Keep the flag out of HOST_EXTRACFLAGS; the bpftool build has its own -Wformat-security anyway.