### PR TITLE
docs: fix stale RELEASE=1 build instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,12 +25,12 @@ sudo dnf -y install elfutils-devel zlib-devel
 # Initialize submodules (first time only)
 git submodule update --init --recursive
 
-# Build release version
+# Build release version (the default)
 cd src
-make RELEASE=1 -j$(nproc)
-
-# Build debug version
 make -j$(nproc)
+
+# Build debug version (-O0, -DDEBUG)
+make DEBUG=1 -j$(nproc)
 
 # Clean build artifacts
 make clean


### PR DESCRIPTION
Debug became opt-in and release the default in a4a89c8 ("Makefile: make debug build an opt-in and release a default"); RELEASE is no longer read by the Makefile, so RELEASE=1 was a no-op.