### PR TITLE
cuda: capture CUPTI overhead activity records

### DIFF
--- a/JSON_SCHEMA.md
+++ b/JSON_SCHEMA.md
@@ -578,6 +578,35 @@ thread-level event.
 }
 ```
 
+#### `cuda_overhead` — CUPTI/driver overhead
+
+CUPTI-reported overhead such as buffer flush, JIT/driver compilation, and
+module loading. Attribution follows CUPTI's object model: thread-attributed
+overhead is associated with the offending thread, while process- and
+device/context/stream-attributed overhead is associated with the owning
+process. `device_id`, `context_id`, and `stream_id` are emitted only for
+device/context/stream-attributed overhead.
+
+| Field        | Type   | Description                                  |
+|--------------|--------|----------------------------------------------|
+| `task`       | task   | Offending thread, or owning process          |
+| `dur`        | float  | Overhead duration                            |
+| `kind`       | string | Overhead kind (e.g. `"cupti_buffer_flush"`)  |
+| `device_id`  | int    | *(optional)* GPU device ID                   |
+| `context_id` | int    | *(optional)* CUDA context ID                 |
+| `stream_id`  | int    | *(optional)* CUDA stream ID                  |
+
+```json
+{
+  "ts": 1.000300000,
+  "t": "cuda_overhead",
+  "task": {"tid": 1234, "pid": 1000, "comm": "trainer"},
+  "dur": 0.000030000,
+  "cpu": 3,
+  "kind": "cupti_buffer_flush"
+}
+```
+
 ---
 
 ### CUDA GPU events

--- a/src/cuda_data.h
+++ b/src/cuda_data.h
@@ -33,6 +33,7 @@ enum wcuda_event_kind {
 	WCK_CUDA_MEMSET = 52,
 	WCK_CUDA_SYNC = 53,
 	WCK_CUDA_API = 54,
+	WCK_CUDA_OVERHEAD = 55,
 };
 
 enum wcuda_cuda_api_kind {
@@ -40,6 +41,24 @@ enum wcuda_cuda_api_kind {
 	WCUDA_CUDA_API_DRIVER = 1,
 	WCUDA_CUDA_API_RUNTIME = 2,
 };
+
+/* mirrors CUpti_ActivityObjectKind for attributing overhead records */
+enum wcuda_object_kind {
+	WCUDA_OBJ_UNKNOWN = 0,
+	WCUDA_OBJ_PROCESS = 1,
+	WCUDA_OBJ_THREAD = 2,
+	WCUDA_OBJ_DEVICE = 3,
+	WCUDA_OBJ_CONTEXT = 4,
+	WCUDA_OBJ_STREAM = 5,
+};
+
+/* true when attribution uses the dcs union arm (device/context/stream) */
+static inline bool wcuda_obj_is_dcs(u8 object_kind)
+{
+	return object_kind == WCUDA_OBJ_DEVICE ||
+	       object_kind == WCUDA_OBJ_CONTEXT ||
+	       object_kind == WCUDA_OBJ_STREAM;
+}
 
 /* intentionally kept compatible in the first 8 bytes with wprof_event */
 struct wcuda_event {
@@ -100,6 +119,23 @@ struct wcuda_event {
 			u32 event_id;
 			u8 sync_type;
 		} cuda_sync;
+		struct wcuda_cuda_overhead {
+			u64 end_ts;
+			u32 overhead_kind;	/* raw CUpti_ActivityOverheadKind */
+			u8 object_kind;		/* enum wcuda_object_kind */
+			/* attribution is object_kind-specific, mirroring CUpti_ActivityObjectKindId */
+			union {
+				struct {
+					u32 pid;
+					u32 tid;
+				} pt;			/* PROCESS/THREAD */
+				struct {
+					u32 device_id;
+					u32 ctx_id;
+					u32 stream_id;
+				} dcs;			/* DEVICE/CONTEXT/STREAM */
+			};
+		} cuda_overhead;
 	};
 };
 

--- a/src/data.c
+++ b/src/data.c
@@ -49,6 +49,7 @@ static const char *event_kind_str_map[] = {
 	[EV_CUDA_MEMSET] = "CUDA_MEMSET",
 	[EV_CUDA_SYNC] = "CUDA_SYNC",
 	[EV_CUDA_API] = "CUDA_API",
+	[EV_CUDA_OVERHEAD] = "CUDA_OVERHEAD",
 
 	/* Python function tracing events */
 	[EV_PYTRACE_ENTRY] = "PYTRACE_ENTRY",

--- a/src/emit.c
+++ b/src/emit.c
@@ -168,6 +168,7 @@ enum dyn_track_kind {
 	DTK_CUDA_PROC_GPU,		/* CUDA-using process's GPU track (id1 = pid, id2 = gpu_id) */
 	DTK_CUDA_PROC_STREAM,		/* CUDA-using process's GPU stream track (id1 = pid, id2 = stream_id) */
 	DTK_CUDA_PROC_STREAM_SYNC,	/* per-stream sync sub-track, merged with the stream (id1 = pid, id2 = stream_id) */
+	DTK_CUDA_PROC_OVERHEAD,		/* CUDA/driver overhead track not attributable to a thread (id1 = pid) */
 
 	DTK_UNRESOLVED,			/* unresolved-ref task track (id1 = tid), child of the UNRESOLVED folder */
 
@@ -184,6 +185,7 @@ enum dyn_track_kind {
 	DTK_PYTRACE,			/* Python-traced thread track (by TID) */
 	DTK_PYTORCH,			/* PyTorch RecordFunction thread track (by TID) */
 	DTK_THREAD_CUDA,		/* per-thread CUDA API calls track (id1 = tid) */
+	DTK_THREAD_CUDA_OVERHEAD,	/* per-thread CUDA/driver overhead track (id1 = tid) */
 	DTK_REQ_THREAD_EMBED,		/* first-event-per-thread tracking for embed mode (id1 = tid, id2 = req_id) */
 	DTK_UTRACE,			/* utrace per-config track (id1 = tid, id2 = utrace_id) */
 };
@@ -244,7 +246,9 @@ static size_t track_state_size(enum dyn_track_kind kind)
 	case DTK_CUDA_PROC:
 	case DTK_CUDA_PROC_GPU:
 	case DTK_CUDA_PROC_STREAM_SYNC:
+	case DTK_CUDA_PROC_OVERHEAD:
 	case DTK_THREAD_CUDA:
+	case DTK_THREAD_CUDA_OVERHEAD:
 	case DTK_UNRESOLVED:
 		return offsetof(struct track_state, req);
 	default:
@@ -3279,8 +3283,9 @@ static u64 ensure_cuda_proc_track(int pid, const char *proc_name)
 	struct track_state *s = track_state_get_or_add(DTK_CUDA_PROC, pid, 0);
 
 	if (!s->exists) {
-		emit_track_descr(s->track_id, TRACK_UUID_CUDA,
-				 sfmt("%s %d (CUDA)", proc_name, pid), 0);
+		emit_track_descr_impl(s->track_id, TRACK_UUID_CUDA,
+				      sfmt("%s %d (CUDA)", proc_name, pid), 0,
+				      CHILD_ORDER_CHRONO, MERGE_BY_NAME);
 		s->exists = true;
 	}
 	return s->track_id;
@@ -3338,7 +3343,41 @@ static u64 ensure_cuda_api_track(int tid, const char *comm)
 
 	if (!s->exists) {
 		emit_track_descr_impl(s->track_id, TRACK_UUID(TK_THREAD, tid),
-				      "CUDA", s->kind, CHILD_ORDER_CHRONO, MERGE_NONE);
+				      "CUDA", s->kind, CHILD_ORDER_CHRONO, MERGE_BY_NAME);
+		s->exists = true;
+	}
+	return s->track_id;
+}
+
+/*
+ * Overhead rides its own track (so it can overlap the API slices without
+ * breaking nesting), but shares the "CUDA" name so Perfetto merges it into the
+ * thread's CUDA API row instead of showing a separate overhead track.
+ */
+static u64 ensure_cuda_overhead_thread_track(int tid, const char *comm)
+{
+	struct track_state *s = track_state_get_or_add(DTK_THREAD_CUDA_OVERHEAD, tid, 0);
+
+	if (!s->exists) {
+		emit_track_descr_impl(s->track_id, TRACK_UUID(TK_THREAD, tid),
+				      "CUDA", DTK_THREAD_CUDA, CHILD_ORDER_CHRONO, MERGE_BY_NAME);
+		s->exists = true;
+	}
+	return s->track_id;
+}
+
+/*
+ * Process-attributed overhead (device/context/stream) merges into the process's
+ * "(CUDA)" row, matching the by-name merge used for the per-thread case.
+ */
+static u64 ensure_cuda_overhead_proc_track(int pid, const char *proc_name)
+{
+	struct track_state *s = track_state_get_or_add(DTK_CUDA_PROC_OVERHEAD, pid, 0);
+
+	if (!s->exists) {
+		emit_track_descr_impl(s->track_id, TRACK_UUID_CUDA,
+				      sfmt("%s %d (CUDA)", proc_name, pid), 0,
+				      CHILD_ORDER_CHRONO, MERGE_BY_NAME);
 		s->exists = true;
 	}
 	return s->track_id;
@@ -3879,6 +3918,92 @@ static int process_cuda_api(struct worker_state *w, const struct wevent *e)
 		emit_cuda_api_json(w, e);
 	else
 		emit_cuda_api(w, e);
+	return 0;
+}
+
+/* WCK_CUDA_OVERHEAD */
+static void emit_cuda_overhead(struct worker_state *w, const struct wevent *e)
+{
+	const struct wevent_cuda_overhead *ov = &e->cuda_overhead;
+	struct wprof_data_hdr *hdr = w->dump_hdr;
+	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
+	bool dcs = wcuda_obj_is_dcs(ov->object_kind);
+	u64 track_uuid;
+
+	/*
+	 * Thread-attributed overhead (e.g. JIT/driver compilation) rides a
+	 * dedicated per-thread track; everything else (buffer flush, device/
+	 * stream/context work) lands on a per-process overhead track so it never
+	 * crosses the thread's own slices.
+	 */
+	if (ov->object_kind == WCUDA_OBJ_THREAD) {
+		emit_track_descrs(w, &task);
+		track_uuid = ensure_cuda_overhead_thread_track(task.tid, task.comm);
+	} else {
+		track_uuid = ensure_cuda_overhead_proc_track(task.pid, task.pcomm);
+	}
+
+	int kind = cuda_overhead_kind_compact(ov->overhead_kind);
+	pb_iid name_iid = IID_NAME_CUDA_OVERHEAD + kind;
+	pb_iid kind_iid = IID_ANNV_CUDA_OVERHEAD_KIND + kind;
+	const char *kind_str = cuda_overhead_kind_str(kind);
+	struct pb_str name = iid_str(name_iid, sfmt("%s:%s", "overhead", kind_str));
+
+	emit_slice_begin(track_uuid, clamp_ts(e->ts), name, IID_CAT_CUDA_OVERHEAD) {
+		emit_kv_str(IID_ANNK_CUDA_KIND, iid_str(kind_iid, kind_str));
+		if (dcs) {
+			emit_kv_int(IID_ANNK_CUDA_DEVICE_ID, ov->device_id);
+			emit_kv_int(IID_ANNK_CUDA_CONTEXT_ID, ov->ctx_id);
+			emit_kv_int(IID_ANNK_CUDA_STREAM_ID, ov->stream_id);
+		}
+	}
+
+	emit_slice_end(track_uuid, clamp_ts(ov->end_ts), name, IID_CAT_CUDA_OVERHEAD);
+}
+
+static void emit_cuda_overhead_json(struct worker_state *w, const struct wevent *e)
+{
+	struct json_state *j = &js;
+	const struct wevent_cuda_overhead *ov = &e->cuda_overhead;
+	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
+
+	json_obj_start(j);
+	json_kv_ts(j, "ts", clamp_ts(e->ts) - env.sess_start_ts);
+	json_kv_str(j, "t", "cuda_overhead");
+	json_task(j, "task", &task);
+	json_kv_ts(j, "dur", clamp_ts(ov->end_ts) - clamp_ts(e->ts));
+	json_kv_int(j, "cpu", e->cpu);
+	if (env.emit_numa)
+		json_kv_int(j, "numa", e->numa_node);
+	json_kv_str(j, "kind", cuda_overhead_kind_str(cuda_overhead_kind_compact(ov->overhead_kind)));
+	if (wcuda_obj_is_dcs(ov->object_kind)) {
+		json_kv_int(j, "device_id", ov->device_id);
+		json_kv_int(j, "context_id", ov->ctx_id);
+		json_kv_int(j, "stream_id", ov->stream_id);
+	}
+	json_obj_end(j);
+}
+
+static int process_cuda_overhead(struct worker_state *w, const struct wevent *e)
+{
+	if (!env.capture_cuda)
+		return 0;
+
+	struct wprof_task task = wevent_resolve_task(w->dump_hdr, e->task_id);
+	if (!should_trace_task(&task))
+		return 0;
+
+	if (!is_time_range_in_session(e->ts, e->cuda_overhead.end_ts))
+		return 0;
+
+	/* check if we failed to resolve TID at data capture time */
+	if (task.tid == 0)
+		return 0;
+
+	if (env.json_path)
+		emit_cuda_overhead_json(w, e);
+	else
+		emit_cuda_overhead(w, e);
 	return 0;
 }
 
@@ -4591,6 +4716,7 @@ static handle_event_fn emit_fns[] = {
 	[EV_CUDA_MEMSET] = process_cuda_memset,
 	[EV_CUDA_SYNC] = process_cuda_sync,
 	[EV_CUDA_API] = process_cuda_api,
+	[EV_CUDA_OVERHEAD] = process_cuda_overhead,
 	[EV_PYTRACE_ENTRY] = process_pytrace,
 	[EV_PYTRACE_EXIT] = process_pytrace,
 	[EV_PYTORCH_ENTRY] = process_pytorch,

--- a/src/inj_cupti.c
+++ b/src/inj_cupti.c
@@ -372,6 +372,44 @@ static int handle_cupti_record(CUpti_Activity *rec)
 		};
 		return cuda_dump_event(&e);
 	}
+	case CUPTI_ACTIVITY_KIND_OVERHEAD: {
+		CUpti_ActivityOverhead *r = (CUpti_ActivityOverhead *)rec;
+
+		u64 start_ts = gpu_to_cpu_time_ns(r->start);
+		u64 end_ts = gpu_to_cpu_time_ns(r->end);
+		if (!rec_within_session(start_ts, end_ts, run_ctx->sess_start_ts, run_ctx->sess_end_ts))
+			return -ENODATA;
+
+		struct wcuda_event e = {
+			.sz = sizeof(e),
+			.kind = WCK_CUDA_OVERHEAD,
+			.ts = start_ts,
+			.cuda_overhead = {
+				.end_ts = end_ts,
+				.overhead_kind = r->overheadKind,
+				.object_kind = r->objectKind,
+			},
+		};
+		switch (r->objectKind) {
+		case CUPTI_ACTIVITY_OBJECT_PROCESS:
+			e.cuda_overhead.pt.pid = r->objectId.pt.processId;
+			break;
+		case CUPTI_ACTIVITY_OBJECT_THREAD:
+			e.cuda_overhead.pt.pid = r->objectId.pt.processId;
+			e.cuda_overhead.pt.tid = r->objectId.pt.threadId;
+			break;
+		case CUPTI_ACTIVITY_OBJECT_DEVICE:
+		case CUPTI_ACTIVITY_OBJECT_CONTEXT:
+		case CUPTI_ACTIVITY_OBJECT_STREAM:
+			e.cuda_overhead.dcs.device_id = r->objectId.dcs.deviceId;
+			e.cuda_overhead.dcs.ctx_id = r->objectId.dcs.contextId;
+			e.cuda_overhead.dcs.stream_id = r->objectId.dcs.streamId;
+			break;
+		default:
+			break;
+		}
+		return cuda_dump_event(&e);
+	}
 	case CUPTI_ACTIVITY_KIND_CUDA_EVENT:
 		/*
 		 * XXX: event is a means to connect GPU-side sync scope with CPU-side sync API call,
@@ -495,6 +533,7 @@ static CUpti_ActivityKind cupti_act_kinds[] = {
 	CUPTI_ACTIVITY_KIND_RUNTIME,
 	CUPTI_ACTIVITY_KIND_MEMSET,
 	CUPTI_ACTIVITY_KIND_SYNCHRONIZATION,
+	CUPTI_ACTIVITY_KIND_OVERHEAD,
 };
 
 static const char *cupti_act_kind_strs[] = {
@@ -506,6 +545,7 @@ static const char *cupti_act_kind_strs[] = {
 	[CUPTI_ACTIVITY_KIND_MEMSET] = "MEMSET",
 	[CUPTI_ACTIVITY_KIND_SYNCHRONIZATION] = "SYNCHRONIZATION",
 	[CUPTI_ACTIVITY_KIND_CUDA_EVENT] = "EVENT",
+	[CUPTI_ACTIVITY_KIND_OVERHEAD] = "OVERHEAD",
 };
 
 static const char *cupti_act_kind_str(CUpti_ActivityKind kind)

--- a/src/persist.c
+++ b/src/persist.c
@@ -732,6 +732,26 @@ int persist_cuda_event(struct persist_state *ps, const struct wcuda_event *e, st
 		dst->cuda_sync.sync_type = e->cuda_sync.sync_type;
 		break;
 
+	case WCK_CUDA_OVERHEAD: {
+		bool dcs = wcuda_obj_is_dcs(e->cuda_overhead.object_kind);
+		if (e->cuda_overhead.object_kind == WCUDA_OBJ_THREAD)
+			ti = resolve_cuda_host_tid(ps, host_pid, proc_name,
+						   e->cuda_overhead.pt.pid, e->cuda_overhead.pt.tid);
+		else if (e->cuda_overhead.object_kind == WCUDA_OBJ_PROCESS)
+			ti = resolve_cuda_host_tid(ps, host_pid, proc_name, host_pid, host_pid);
+		else /* DEVICE/CONTEXT/STREAM */
+			ti = resolve_cuda_host_tid(ps, host_pid, proc_name, host_pid, host_pid);
+		fill_cuda_wevent_hdr(dst, e, EV_CUDA_OVERHEAD, ti->task_id, WEVENT_SZ(cuda_overhead));
+
+		dst->cuda_overhead.end_ts = e->cuda_overhead.end_ts;
+		dst->cuda_overhead.overhead_kind = e->cuda_overhead.overhead_kind;
+		dst->cuda_overhead.object_kind = e->cuda_overhead.object_kind;
+		dst->cuda_overhead.device_id = dcs ? e->cuda_overhead.dcs.device_id : 0;
+		dst->cuda_overhead.ctx_id = dcs ? e->cuda_overhead.dcs.ctx_id : 0;
+		dst->cuda_overhead.stream_id = dcs ? e->cuda_overhead.dcs.stream_id : 0;
+		break;
+	}
+
 	default:
 		BUG("unrecognized CUDA event type %d while persisting\n", e->kind);
 	}

--- a/src/protobuf.c
+++ b/src/protobuf.c
@@ -143,6 +143,43 @@ const char *cuda_sync_type_str(int type)
 	return cuda_sync_type_str_map[0];
 }
 
+static const char *cuda_overhead_kind_str_map[] = {
+	[CUDA_OVERHEAD_UNKN]                    = "???",
+	[CUDA_OVERHEAD_DRIVER_COMPILER]         = "driver_compiler",
+	[CUDA_OVERHEAD_BUFFER_FLUSH]            = "cupti_buffer_flush",
+	[CUDA_OVERHEAD_INSTRUMENTATION]         = "cupti_instrumentation",
+	[CUDA_OVERHEAD_RESOURCE]                = "cupti_resource",
+	[CUDA_OVERHEAD_MODULE_LOADING]          = "module_loading",
+	[CUDA_OVERHEAD_LAZY_FUNCTION_LOADING]   = "lazy_function_loading",
+	[CUDA_OVERHEAD_COMMAND_BUFFER_FULL]     = "command_buffer_full",
+	[CUDA_OVERHEAD_ACTIVITY_BUFFER_REQUEST] = "activity_buffer_request",
+	[CUDA_OVERHEAD_UVM_ACTIVITY_INIT]       = "uvm_activity_init",
+};
+
+const char *cuda_overhead_kind_str(int kind)
+{
+	if (kind > 0 && kind < ARRAY_SIZE(cuda_overhead_kind_str_map))
+		return cuda_overhead_kind_str_map[kind];
+	return cuda_overhead_kind_str_map[CUDA_OVERHEAD_UNKN];
+}
+
+/* raw CUpti_ActivityOverheadKind values are sparse (1, then N<<16) */
+int cuda_overhead_kind_compact(u32 raw_overhead_kind)
+{
+	switch (raw_overhead_kind) {
+	case 1:		return CUDA_OVERHEAD_DRIVER_COMPILER;
+	case 1 << 16:	return CUDA_OVERHEAD_BUFFER_FLUSH;
+	case 2 << 16:	return CUDA_OVERHEAD_INSTRUMENTATION;
+	case 3 << 16:	return CUDA_OVERHEAD_RESOURCE;
+	case 4 << 16:	return CUDA_OVERHEAD_MODULE_LOADING;
+	case 5 << 16:	return CUDA_OVERHEAD_LAZY_FUNCTION_LOADING;
+	case 6 << 16:	return CUDA_OVERHEAD_COMMAND_BUFFER_FULL;
+	case 7 << 16:	return CUDA_OVERHEAD_ACTIVITY_BUFFER_REQUEST;
+	case 8 << 16:	return CUDA_OVERHEAD_UVM_ACTIVITY_INIT;
+	default:	return CUDA_OVERHEAD_UNKN;
+	}
+}
+
 /*
  * PROTOBUF UTILS
  */
@@ -186,6 +223,7 @@ static const char *pb_static_strs[] = {
 	[IID_CAT_CUDA_API] = "CUDA_API",
 	[IID_CAT_CUDA_MEMSET] = "CUDA_MEMSET",
 	[IID_CAT_CUDA_SYNC] = "CUDA_SYNC",
+	[IID_CAT_CUDA_OVERHEAD] = "CUDA_OVERHEAD",
 	[IID_CAT_SCX_DSQ] = "SCX_DSQ",
 	[IID_CAT_PYTRACE] = "PYTRACE",
 	[IID_CAT_PYTORCH] = "PYTORCH",
@@ -262,6 +300,16 @@ static const char *pb_static_strs[] = {
 	[IID_NAME_CUDA_SYNC + CUDA_SYNC_STREAM_WAIT_EVENT] = "sync:stream_wait_event",
 	[IID_NAME_CUDA_SYNC + CUDA_SYNC_STREAM_SYNC] = "sync:stream_sync",
 	[IID_NAME_CUDA_SYNC + CUDA_SYNC_CONTEXT_SYNC] = "sync:context_sync",
+	[IID_NAME_CUDA_OVERHEAD + CUDA_OVERHEAD_UNKN] = "overhead:???",
+	[IID_NAME_CUDA_OVERHEAD + CUDA_OVERHEAD_DRIVER_COMPILER] = "overhead:driver_compiler",
+	[IID_NAME_CUDA_OVERHEAD + CUDA_OVERHEAD_BUFFER_FLUSH] = "overhead:cupti_buffer_flush",
+	[IID_NAME_CUDA_OVERHEAD + CUDA_OVERHEAD_INSTRUMENTATION] = "overhead:cupti_instrumentation",
+	[IID_NAME_CUDA_OVERHEAD + CUDA_OVERHEAD_RESOURCE] = "overhead:cupti_resource",
+	[IID_NAME_CUDA_OVERHEAD + CUDA_OVERHEAD_MODULE_LOADING] = "overhead:module_loading",
+	[IID_NAME_CUDA_OVERHEAD + CUDA_OVERHEAD_LAZY_FUNCTION_LOADING] = "overhead:lazy_function_loading",
+	[IID_NAME_CUDA_OVERHEAD + CUDA_OVERHEAD_COMMAND_BUFFER_FULL] = "overhead:command_buffer_full",
+	[IID_NAME_CUDA_OVERHEAD + CUDA_OVERHEAD_ACTIVITY_BUFFER_REQUEST] = "overhead:activity_buffer_request",
+	[IID_NAME_CUDA_OVERHEAD + CUDA_OVERHEAD_UVM_ACTIVITY_INIT] = "overhead:uvm_activity_init",
 
 	[IID_ANNK_CPU] = "cpu",
 	[IID_ANNK_NUMA_NODE] = "numa_node",
@@ -373,6 +421,17 @@ static const char *pb_static_strs[] = {
 	[IID_ANNV_CUDA_SYNC_TYPE + CUDA_SYNC_STREAM_WAIT_EVENT] = "stream_wait_event",
 	[IID_ANNV_CUDA_SYNC_TYPE + CUDA_SYNC_STREAM_SYNC] = "stream_sync",
 	[IID_ANNV_CUDA_SYNC_TYPE + CUDA_SYNC_CONTEXT_SYNC] = "context_sync",
+
+	[IID_ANNV_CUDA_OVERHEAD_KIND + CUDA_OVERHEAD_UNKN] = "???",
+	[IID_ANNV_CUDA_OVERHEAD_KIND + CUDA_OVERHEAD_DRIVER_COMPILER] = "driver_compiler",
+	[IID_ANNV_CUDA_OVERHEAD_KIND + CUDA_OVERHEAD_BUFFER_FLUSH] = "cupti_buffer_flush",
+	[IID_ANNV_CUDA_OVERHEAD_KIND + CUDA_OVERHEAD_INSTRUMENTATION] = "cupti_instrumentation",
+	[IID_ANNV_CUDA_OVERHEAD_KIND + CUDA_OVERHEAD_RESOURCE] = "cupti_resource",
+	[IID_ANNV_CUDA_OVERHEAD_KIND + CUDA_OVERHEAD_MODULE_LOADING] = "module_loading",
+	[IID_ANNV_CUDA_OVERHEAD_KIND + CUDA_OVERHEAD_LAZY_FUNCTION_LOADING] = "lazy_function_loading",
+	[IID_ANNV_CUDA_OVERHEAD_KIND + CUDA_OVERHEAD_COMMAND_BUFFER_FULL] = "command_buffer_full",
+	[IID_ANNV_CUDA_OVERHEAD_KIND + CUDA_OVERHEAD_ACTIVITY_BUFFER_REQUEST] = "activity_buffer_request",
+	[IID_ANNV_CUDA_OVERHEAD_KIND + CUDA_OVERHEAD_UVM_ACTIVITY_INIT] = "uvm_activity_init",
 
 	[IID_ANNV_OFFCPU_BLOCKED] = "blocked",
 	[IID_ANNV_OFFCPU_PREEMPTED] = "preempted",

--- a/src/protobuf.h
+++ b/src/protobuf.h
@@ -86,9 +86,32 @@ enum cuda_sync_type {
 	NR_CUDA_SYNC_TYPE,
 };
 
+/*
+ * Dense re-numbering of CUpti_ActivityOverheadKind, whose raw values are
+ * sparse (1, then 1<<16, 2<<16, ...). cuda_overhead_kind_compact() maps the
+ * raw wire value onto this compact enum.
+ */
+enum cuda_overhead_kind {
+	CUDA_OVERHEAD_UNKN = 0,
+
+	CUDA_OVERHEAD_DRIVER_COMPILER = 1,
+	CUDA_OVERHEAD_BUFFER_FLUSH = 2,
+	CUDA_OVERHEAD_INSTRUMENTATION = 3,
+	CUDA_OVERHEAD_RESOURCE = 4,
+	CUDA_OVERHEAD_MODULE_LOADING = 5,
+	CUDA_OVERHEAD_LAZY_FUNCTION_LOADING = 6,
+	CUDA_OVERHEAD_COMMAND_BUFFER_FULL = 7,
+	CUDA_OVERHEAD_ACTIVITY_BUFFER_REQUEST = 8,
+	CUDA_OVERHEAD_UVM_ACTIVITY_INIT = 9,
+
+	NR_CUDA_OVERHEAD_KIND,
+};
+
 const char *cuda_memcpy_kind_str(enum cuda_memcpy_kind);
 const char *cuda_sync_type_str(int type);
 const char *cuda_memory_kind_str(int kind);
+const char *cuda_overhead_kind_str(int kind);
+int cuda_overhead_kind_compact(u32 raw_overhead_kind);
 
 enum pb_static_iid {
 	IID_NONE = 0,
@@ -133,6 +156,7 @@ enum pb_static_iid {
 		IID_CAT_CUDA_API, 				/* CUDA_API */
 		IID_CAT_CUDA_MEMSET, 				/* CUDA_MEMSET */
 		IID_CAT_CUDA_SYNC,				/* CUDA_SYNC */
+		IID_CAT_CUDA_OVERHEAD,				/* CUDA_OVERHEAD */
 		IID_CAT_SCX_DSQ,				/* SCX_DSQ */
 		IID_CAT_PYTRACE,				/* PYTRACE */
 		IID_CAT_PYTORCH,				/* PYTORCH */
@@ -181,6 +205,8 @@ enum pb_static_iid {
 		IID_NAME_CUDA_MEMSET_LAST = IID_NAME_CUDA_MEMSET + NR_CUDA_MEMORY_KIND - 1,
 		IID_NAME_CUDA_SYNC,				/* sync:... */
 		IID_NAME_CUDA_SYNC_LAST = IID_NAME_CUDA_SYNC + NR_CUDA_SYNC_TYPE - 1,
+		IID_NAME_CUDA_OVERHEAD,				/* overhead:... */
+		IID_NAME_CUDA_OVERHEAD_LAST = IID_NAME_CUDA_OVERHEAD + NR_CUDA_OVERHEAD_KIND - 1,
 	NAME_END_IID,
 
 	ANNK_START_IID, __ANNK_RESET_IID = ANNK_START_IID - 1,
@@ -265,6 +291,8 @@ enum pb_static_iid {
 		IID_ANNV_CUDA_MEMORY_KIND_LAST = IID_ANNV_CUDA_MEMORY_KIND + NR_CUDA_MEMORY_KIND - 1,
 		IID_ANNV_CUDA_SYNC_TYPE,			/* event_sync, stream_sync, etc. */
 		IID_ANNV_CUDA_SYNC_TYPE_LAST = IID_ANNV_CUDA_SYNC_TYPE + NR_CUDA_SYNC_TYPE - 1,
+		IID_ANNV_CUDA_OVERHEAD_KIND,			/* driver_compiler, buffer_flush, etc. */
+		IID_ANNV_CUDA_OVERHEAD_KIND_LAST = IID_ANNV_CUDA_OVERHEAD_KIND + NR_CUDA_OVERHEAD_KIND - 1,
 	ANNV_END_IID,
 
 	IID_FIXED_LAST_ID,

--- a/src/wevent.h
+++ b/src/wevent.h
@@ -220,6 +220,15 @@ struct wevent {
 			u8 sync_type;
 		} cuda_sync;
 
+		struct wevent_cuda_overhead {
+			u64 end_ts;
+			u32 overhead_kind;	/* raw CUpti_ActivityOverheadKind */
+			u32 device_id;
+			u32 ctx_id;
+			u32 stream_id;
+			u8 object_kind;		/* enum wcuda_object_kind */
+		} cuda_overhead;
+
 		/* Python function tracing events (from PyEval_SetProfile) */
 		struct wevent_pytrace {
 			u32 func_name_stroff;
@@ -278,6 +287,7 @@ static inline size_t wevent_fixed_sz(const struct wevent *e)
 	case EV_CUDA_MEMSET:	return WEVENT_SZ(cuda_memset);
 	case EV_CUDA_SYNC:	return WEVENT_SZ(cuda_sync);
 	case EV_CUDA_API:	return WEVENT_SZ(cuda_api);
+	case EV_CUDA_OVERHEAD:	return WEVENT_SZ(cuda_overhead);
 
 	case EV_PYTRACE_ENTRY:	return WEVENT_SZ(pytrace);
 	case EV_PYTRACE_EXIT:	return WEVENT_SZ(pytrace);
@@ -321,6 +331,7 @@ static inline const char *wevent_kind_name(enum event_kind kind)
 	case EV_CUDA_MEMSET:	return "cuda_memset";
 	case EV_CUDA_SYNC:	return "cuda_sync";
 	case EV_CUDA_API:	return "cuda_api";
+	case EV_CUDA_OVERHEAD:	return "cuda_overhead";
 	case EV_PYTRACE_ENTRY:	return "pytrace_entry";
 	case EV_PYTRACE_EXIT:	return "pytrace_exit";
 	case EV_PYTORCH_ENTRY:	return "pytorch_entry";

--- a/src/wprof.h
+++ b/src/wprof.h
@@ -97,6 +97,7 @@ enum event_kind {
 	EV_CUDA_MEMSET = 52,
 	EV_CUDA_SYNC = 53,
 	EV_CUDA_API = 54,
+	EV_CUDA_OVERHEAD = 55,
 
 	/* Python function tracing events (from PyEval_SetProfile) */
 	EV_PYTRACE_ENTRY = 60,

--- a/src/wprof_cupti.h
+++ b/src/wprof_cupti.h
@@ -36,6 +36,7 @@ typedef enum {
 	CUPTI_ACTIVITY_KIND_DRIVER              = 4,
 	CUPTI_ACTIVITY_KIND_RUNTIME             = 5,
 	CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL   = 10,
+	CUPTI_ACTIVITY_KIND_OVERHEAD            = 17,
 	CUPTI_ACTIVITY_KIND_MEMCPY2             = 22,
 	CUPTI_ACTIVITY_KIND_CUDA_EVENT          = 36,
 	CUPTI_ACTIVITY_KIND_SYNCHRONIZATION     = 38,
@@ -251,6 +252,56 @@ typedef struct CUPTI_PACKED_ALIGNMENT {
 	uint32_t streamId;
 	uint32_t cudaEventId;
 } CUpti_ActivitySynchronization;
+
+typedef enum {
+	CUPTI_ACTIVITY_OBJECT_UNKNOWN   = 0,
+	CUPTI_ACTIVITY_OBJECT_PROCESS   = 1,
+	CUPTI_ACTIVITY_OBJECT_THREAD    = 2,
+	CUPTI_ACTIVITY_OBJECT_DEVICE    = 3,
+	CUPTI_ACTIVITY_OBJECT_CONTEXT   = 4,
+	CUPTI_ACTIVITY_OBJECT_STREAM    = 5,
+} CUpti_ActivityObjectKind;
+
+typedef union {
+	struct {
+		uint32_t processId;
+		uint32_t threadId;
+	} pt;
+	struct {
+		uint32_t deviceId;
+		uint32_t contextId;
+		uint32_t streamId;
+	} dcs;
+} CUpti_ActivityObjectKindId;
+
+typedef enum {
+	CUPTI_ACTIVITY_OVERHEAD_UNKNOWN                          = 0,
+	CUPTI_ACTIVITY_OVERHEAD_DRIVER_COMPILER                  = 1,
+	CUPTI_ACTIVITY_OVERHEAD_CUPTI_BUFFER_FLUSH               = 1 << 16,
+	CUPTI_ACTIVITY_OVERHEAD_CUPTI_INSTRUMENTATION            = 2 << 16,
+	CUPTI_ACTIVITY_OVERHEAD_CUPTI_RESOURCE                   = 3 << 16,
+	CUPTI_ACTIVITY_OVERHEAD_RUNTIME_TRIGGERED_MODULE_LOADING = 4 << 16,
+	CUPTI_ACTIVITY_OVERHEAD_LAZY_FUNCTION_LOADING            = 5 << 16,
+	CUPTI_ACTIVITY_OVERHEAD_COMMAND_BUFFER_FULL              = 6 << 16,
+	CUPTI_ACTIVITY_OVERHEAD_ACTIVITY_BUFFER_REQUEST          = 7 << 16,
+	CUPTI_ACTIVITY_OVERHEAD_UVM_ACTIVITY_INIT                = 8 << 16,
+} CUpti_ActivityOverheadKind;
+
+/*
+ * Only the prefix through 'end' is declared; later CUPTI revisions append a
+ * trailing correlationId, but CUPTI 12.4 (the version in use here) does not
+ * carry one, so we deliberately stop at the version-stable fields.
+ */
+typedef struct CUPTI_PACKED_ALIGNMENT {
+	CUpti_ActivityKind kind;
+
+	CUpti_ActivityOverheadKind overheadKind;
+	CUpti_ActivityObjectKind objectKind;
+	CUpti_ActivityObjectKindId objectId;
+
+	uint64_t start;
+	uint64_t end;
+} CUpti_ActivityOverhead;
 
 enum CUpti_driver_api_trace_cbid {
 	/* uninteresting high-frequency APIs */


### PR DESCRIPTION
Add a CUDA_OVERHEAD event carrying CUPTI_ACTIVITY_KIND_OVERHEAD records (driver/JIT compilation, buffer flush, module loading, etc.) with their duration and overhead kind.

Attribution mirrors CUPTI's object model: thread-attributed overhead is charged to the offending thread, while process- and device/context/ stream-attributed overhead is charged to the owning process. The injectee records the object kind plus either the namespaced pid/tid or the device/context/stream ids; persist resolves the host tid and drops records whose thread cannot be resolved.

In Perfetto, overhead slices share the "CUDA" track name so they merge into the thread's CUDA API row (or the process's (CUDA) row). JSON gains a cuda_overhead event with device/context/stream ids for the corresponding records, documented in JSON_SCHEMA.md.