### PR TITLE
req: safely read request names

### DIFF
--- a/src/wprof.bpf.c
+++ b/src/wprof.bpf.c
@@ -1799,7 +1799,7 @@ int BPF_USDT(wprof_req_ctx, u64 req_id, const char *endpoint, enum wprof_req_eve
 		e->req.req_id = req_id;
 		e->req.req_ts = s->start_ts;
 		e->req.req_event = event_kind;
-		if (bpf_probe_read_user(&e->req.req_name, sizeof(e->req.req_name), endpoint))
+		if (bpf_probe_read_user_str(e->req.req_name, sizeof(e->req.req_name), endpoint) < 0)
 			e->req.req_name[0] = '\0';
 		if (tr) {
 			emit_stack_trace(tr, dyn_sz, dptr, fix_sz);


### PR DESCRIPTION
bpf_probe_read_user() reads the full 64-byte field even when the source string is shorter. It can therefore cross into an unmapped page and drop the name, and a name of 64 bytes or longer is left without a terminating NUL so userspace reads into the trailing event data.

Use bpf_probe_read_user_str() to stop at the source NUL and always terminate truncated names within the existing 64-byte field.