### PR TITLE
wprof: capture parent process id and emit process tree

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -400,6 +400,7 @@ static inline struct wprof_task wevent_resolve_task(struct wprof_data_hdr *hdr, 
 	return (struct wprof_task) {
 		.tid = t->tid,
 		.pid = t->pid,
+		.ppid = t->ppid,
 		.flags = t->flags,
 		.comm = wevent_str(hdr, t->comm_stroff),
 		.pcomm = wevent_str(hdr, t->pcomm_stroff),

--- a/src/emit.c
+++ b/src/emit.c
@@ -1111,6 +1111,13 @@ static void emit_process_track_descr(const struct wprof_task *t)
 		/* sibling_merge_behavior left as default (mergeable) */
 	};
 	wpb_emit_track_descriptor_with_interns(&desc);
+
+	struct wpb_kernel_process proc = {
+		.pid = track_pid(t),
+		.ppid = t->ppid,
+		.cmdline = wpb_str_from_cstr(0, pcomm),
+	};
+	wpb_emit_generic_kernel_process_tree(cur_wpb_writer, &proc, 1);
 }
 
 static void emit_thread_track_descr(const struct wprof_task *t, const char *comm)

--- a/src/persist.c
+++ b/src/persist.c
@@ -125,6 +125,7 @@ static void persist_update_task_slot(struct persist_state *ps, int task_id, cons
 
 	entry->tid = task->tid;
 	entry->pid = task->pid;
+	entry->ppid = task->ppid;
 	entry->flags = task->flags;
 	entry->comm_stroff = persist_stroff(ps, task->comm);
 	entry->pcomm_stroff = persist_stroff(ps, task->pcomm);

--- a/src/wevent.h
+++ b/src/wevent.h
@@ -19,6 +19,7 @@
 struct wevent_task {
 	u32 tid;
 	u32 pid;
+	u32 ppid;
 	u32 flags;
 	u32 comm_stroff;	/* offset into string pool */
 	u32 pcomm_stroff;	/* offset into string pool */

--- a/src/wpb.h
+++ b/src/wpb.h
@@ -185,6 +185,12 @@ struct wpb_ftrace_event {
 	int32_t target_cpu;
 };
 
+struct wpb_kernel_process {
+	int64_t pid;
+	int64_t ppid;
+	struct wpb_str cmdline;
+};
+
 void wpb_emit_track_event(struct wpb_writer *writer,
 			  const struct wpb_track_event *ev);
 void wpb_emit_clock_snapshot(struct wpb_writer *writer, uint64_t realtime_ts);
@@ -199,6 +205,8 @@ void wpb_emit_trace_start(struct wpb_writer *writer, uint64_t track_uuid,
 			  const struct wpb_interned_data *data);
 void wpb_emit_track_descriptor(struct wpb_writer *writer,
 			       const struct wpb_track_descriptor *desc);
+void wpb_emit_generic_kernel_process_tree(struct wpb_writer *writer,
+					  const struct wpb_kernel_process *procs, size_t proc_cnt);
 void wpb_emit_ftrace_bundle(struct wpb_writer *writer, uint32_t cpu,
 			    const struct wpb_ftrace_event *events, size_t event_cnt);
 

--- a/src/wpb/build.rs
+++ b/src/wpb/build.rs
@@ -23,6 +23,7 @@ const KEEP_FIELDS: &[(&str, &[&str])] = &[
             "trace_uuid",
             "ftrace_events",
             "interned_data",
+            "generic_kernel_process_tree",
         ],
     ),
     (

--- a/src/wpb/src/lib.rs
+++ b/src/wpb/src/lib.rs
@@ -158,6 +158,13 @@ pub struct WpbTrackDescriptor {
 }
 
 #[repr(C)]
+pub struct WpbKernelProcess {
+    pid: i64,
+    ppid: i64,
+    cmdline: WpbStr,
+}
+
+#[repr(C)]
 pub struct WpbFtraceEvent {
     timestamp: u64,
     pid: u32,
@@ -400,6 +407,25 @@ impl WpbWriter {
             packet.interned_data = Some(interned_data);
         }
         packet.data = Some(trace_packet::Data::TrackDescriptor(td));
+        self.emit_packet(&packet)
+    }
+
+    fn emit_generic_kernel_process_tree(&mut self, procs: &[WpbKernelProcess]) -> Result<(), c_int> {
+        let processes = procs
+            .iter()
+            .map(|p| generic_kernel_process_tree::Process {
+                pid: Some(p.pid),
+                ppid: Some(p.ppid),
+                cmdline: read_string(&p.cmdline),
+            })
+            .collect();
+        let mut packet = base_packet(WPB_SEQ_ID_THREADS);
+        packet.data = Some(trace_packet::Data::GenericKernelProcessTree(
+            GenericKernelProcessTree {
+                processes,
+                threads: Vec::new(),
+            },
+        ));
         self.emit_packet(&packet)
     }
 
@@ -946,6 +972,23 @@ pub unsafe extern "C" fn wpb_emit_track_descriptor(
 
     if let Err(err) = (*writer).emit_track_descriptor(&*desc) {
         wpb_emit_failed("TrackDescriptor", err);
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wpb_emit_generic_kernel_process_tree(
+    writer: *mut WpbWriter,
+    procs: *const WpbKernelProcess,
+    proc_cnt: usize,
+) {
+    if writer.is_null() {
+        wpb_emit_failed("GenericKernelProcessTree", -EINVAL);
+    }
+
+    let procs = checked_slice(procs, proc_cnt);
+
+    if let Err(err) = (*writer).emit_generic_kernel_process_tree(procs) {
+        wpb_emit_failed("GenericKernelProcessTree", err);
     }
 }
 

--- a/src/wprof.bpf.c
+++ b/src/wprof.bpf.c
@@ -393,6 +393,7 @@ static int fill_task_info(struct task_struct *t, struct wprof_thread *info)
 	if (info->tid == 0) /* idle thread */
 		info->tid = -(bpf_get_smp_processor_id() + 1);
 	info->pid = t->tgid;
+	info->ppid = t->group_leader->real_parent->tgid;
 	info->flags = t->flags;
 	fill_task_name(t, info->comm, sizeof(info->comm));
 	__builtin_memcpy(info->pcomm, t->group_leader->comm, sizeof(info->pcomm));

--- a/src/wprof.h
+++ b/src/wprof.h
@@ -202,6 +202,7 @@ struct stack_trace {
 struct wprof_thread {
 	u32 tid;
 	u32 pid;
+	u32 ppid;
 	u32 flags;
 	char comm[TASK_COMM_FULL_LEN];
 	char pcomm[TASK_COMM_LEN];
@@ -210,6 +211,7 @@ struct wprof_thread {
 struct wprof_task {
 	u32 tid;
 	u32 pid;
+	u32 ppid;
 	u32 flags;
 	const char *comm;
 	const char *pcomm;


### PR DESCRIPTION
Record each task's parent process id (ppid) in fill_task_info from group_leader->real_parent->tgid and thread it through wprof_thread, the persisted wevent_task, and the resolved wprof_task.

emit_process_track_descr now emits a Perfetto GenericKernelProcessTree packet per process track (pid, ppid, cmdline), backed by a new wpb_emit_generic_kernel_process_tree FFI over the vendored perfetto GenericKernelProcessTree message. The cmdline field carries the process comm for now; capturing the real command line is a follow-up.