### PR TITLE
utrace: expand utrace with track name (id), flow and k/v annotations with templating

### DIFF
--- a/JSON_SCHEMA.md
+++ b/JSON_SCHEMA.md
@@ -825,7 +825,7 @@ Three event types are emitted depending on the probe kind:
 | Field       | Type            | Description                                                           |
 |-------------|-----------------|-----------------------------------------------------------------------|
 | `task`      | task            | Thread where the probe fired                                          |
-| `utrace_id` | string         | Custom probe ID (from `id:` setting, with `{...}` placeholders rendered) or numeric index as string |
+| `utrace_id` | string          | Custom probe ID (`id:` with placeholders rendered) or numeric index   |
 | `name`      | string          | Event name (probe name or formatted via `name:` template)             |
 | `args`      | object          | *(optional)* Captured arguments as key-value pairs                    |
 | `stack_id`  | int             | *(optional)* Stack trace ID (when `stack` parameter is enabled)       |

--- a/JSON_SCHEMA.md
+++ b/JSON_SCHEMA.md
@@ -829,6 +829,7 @@ Three event types are emitted depending on the probe kind:
 | `name`      | string          | Event name (probe name or formatted via `name:` template)             |
 | `flow_id`   | string          | *(optional)* Rendered `flow:` key, on entry and instant events only   |
 | `args`      | object          | *(optional)* Captured arguments as key-value pairs                    |
+| `anns`      | object          | *(optional)* Rendered `ann:` templates as string key-values           |
 | `stack_id`  | int             | *(optional)* Stack trace ID (when `stack` parameter is enabled)       |
 
 Argument values are formatted by type: integers as decimal numbers,

--- a/JSON_SCHEMA.md
+++ b/JSON_SCHEMA.md
@@ -825,7 +825,7 @@ Three event types are emitted depending on the probe kind:
 | Field       | Type            | Description                                                           |
 |-------------|-----------------|-----------------------------------------------------------------------|
 | `task`      | task            | Thread where the probe fired                                          |
-| `utrace_id` | string         | Custom probe ID (from `id:` setting) or numeric index as string       |
+| `utrace_id` | string         | Custom probe ID (from `id:` setting, with `{arg}` placeholders rendered) or numeric index as string |
 | `name`      | string          | Event name (probe name or formatted via `name:` template)             |
 | `args`      | object          | *(optional)* Captured arguments as key-value pairs                    |
 | `stack_id`  | int             | *(optional)* Stack trace ID (when `stack` parameter is enabled)       |

--- a/JSON_SCHEMA.md
+++ b/JSON_SCHEMA.md
@@ -825,7 +825,7 @@ Three event types are emitted depending on the probe kind:
 | Field       | Type            | Description                                                           |
 |-------------|-----------------|-----------------------------------------------------------------------|
 | `task`      | task            | Thread where the probe fired                                          |
-| `utrace_id` | string         | Custom probe ID (from `id:` setting, with `{arg}` placeholders rendered) or numeric index as string |
+| `utrace_id` | string         | Custom probe ID (from `id:` setting, with `{...}` placeholders rendered) or numeric index as string |
 | `name`      | string          | Event name (probe name or formatted via `name:` template)             |
 | `args`      | object          | *(optional)* Captured arguments as key-value pairs                    |
 | `stack_id`  | int             | *(optional)* Stack trace ID (when `stack` parameter is enabled)       |

--- a/JSON_SCHEMA.md
+++ b/JSON_SCHEMA.md
@@ -827,6 +827,7 @@ Three event types are emitted depending on the probe kind:
 | `task`      | task            | Thread where the probe fired                                          |
 | `utrace_id` | string          | Custom probe ID (`id:` with placeholders rendered) or numeric index   |
 | `name`      | string          | Event name (probe name or formatted via `name:` template)             |
+| `flow_id`   | string          | *(optional)* Rendered `flow:` key, on entry and instant events only   |
 | `args`      | object          | *(optional)* Captured arguments as key-value pairs                    |
 | `stack_id`  | int             | *(optional)* Stack trace ID (when `stack` parameter is enabled)       |
 

--- a/UTRACE.md
+++ b/UTRACE.md
@@ -398,6 +398,24 @@ template renders to a *flow key* per event, and every event rendering
 the same key joins one flow, whatever probe, thread, process or CPU it
 came from. See **Flows** under **Perfetto rendering** below.
 
+### Annotations
+
+`ann:NAME=<template>` or `ann:NAME='template with spaces'`, repeatable
+
+Annotates every event with a NAME key, rendered from the same `{...}`
+argument and `{env:...}` placeholders as `name:`. The annotation appears
+next to the captured argument annotations in Perfetto and under `anns`
+in JSON output:
+
+```bash
+-U 'raw_tp:sched_switch | ann:cpu={env:cpu}, ann:who="{env:comm}/{env:tid}" |'
+```
+
+An annotation that references arguments is omitted on span exit events,
+which carry no entry-side arguments to render it from. One built only
+from `{env:...}` placeholders renders on every event, so a span's entry
+and exit report their own values.
+
 ## Perfetto rendering
 
 Utrace events are captured in the context of the thread that was active
@@ -512,9 +530,9 @@ the context the probe fired in rather than to an argument:
 -U 'usdt:app:req_start (arg:0/name(req)) | name:"{env:comm} req {req}" |'
 ```
 
-These are available to `name:`, `id:` and `flow:`, and unlike arguments
-they are available on every event, so a `name:` template built only from
-them also renders on span exit events. `env:` is a reserved namespace: an
+These are available to `name:`, `id:`, `flow:` and `ann:`, and unlike
+arguments they are available on every event, so a `name:` template built
+only from them also renders on span exit events. `env:` is a reserved namespace: an
 unknown key is rejected when the definition is parsed, whereas a
 placeholder naming no argument is left as literal text.
 
@@ -547,6 +565,9 @@ no entry to pair up with reports the `id:` setting itself.
 `flow_id` carries the rendered `flow:` key when the probe has one, on
 `utrace_entry` and `utrace_instant` events only; exits don't render flow
 templates.
+
+`anns` carries rendered `ann:` values as string key-values; annotations
+referencing arguments are omitted on `utrace_exit` events.
 
 Argument values are formatted by type: integers as decimal, pointers as
 `"0x..."` hex strings, strings as JSON strings. An argument whose value could

--- a/UTRACE.md
+++ b/UTRACE.md
@@ -335,8 +335,8 @@ Settings go inside `| ... |` after the parameters, comma-separated.
 
 `name:<template>` or `name:'template with spaces'`
 
-Customizes event names with `{...}` argument placeholders. See
-**Perfetto rendering** below for details and examples.
+Customizes event names with `{...}` argument and `{env:...}`
+placeholders. See **Perfetto rendering** below for details and examples.
 
 ### Custom probe ID
 
@@ -347,8 +347,9 @@ JSON output instead of the default numeric index. Multiple probes
 sharing the same ID will have their events combined on the same
 per-thread track in Perfetto (see **Perfetto rendering** below).
 
-Like `name:`, the identifier accepts `{...}` argument placeholders, in
-which case each distinct rendered value gets its own track.
+Like `name:`, the identifier accepts `{...}` argument and `{env:...}`
+placeholders, in which case each distinct rendered value gets its own
+track.
 
 ## Perfetto rendering
 
@@ -415,6 +416,37 @@ entry-side arguments can be substituted, so `arg:ret` is not available
 to a template. Captured argument values also appear as annotations on
 the Perfetto slice or instant event. An argument that could not be read
 is omitted from the annotations and renders empty in a template.
+
+**Capture environment:** A placeholder of the form `{env:...}` refers to
+the context the probe fired in rather than to an argument:
+
+| Key           | Value                                             |
+|---------------|---------------------------------------------------|
+| `{env:tid}`   | Thread ID                                         |
+| `{env:pid}`   | Process ID                                        |
+| `{env:ppid}`  | Parent process ID                                 |
+| `{env:comm}`  | Thread name                                       |
+| `{env:pcomm}` | Process name                                      |
+| `{env:cpu}`   | CPU the probe fired on                            |
+| `{env:numa}`  | NUMA node of that CPU                             |
+
+```bash
+# split one probe's spans across a track per CPU
+-U 'kspan:submit_bio | id:"cpu {env:cpu}" |'
+
+# label events with the thread they fired on
+-U 'usdt:app:req_start (arg:0/name(req)) | name:"{env:comm} req {req}" |'
+```
+
+These are available to both `name:` and `id:`, and unlike arguments they
+are available on every event, so a `name:` template built only from them
+also renders on span exit events. `env:` is a reserved namespace: an
+unknown key is rejected when the definition is parsed, whereas a
+placeholder naming no argument is left as literal text.
+
+For a span's `id:`, the value is the one captured at entry. A thread can
+migrate between CPUs, or be renamed, while a span is open, so a slice
+stays on the track its entry opened rather than moving mid-slice.
 
 ## JSON output
 

--- a/UTRACE.md
+++ b/UTRACE.md
@@ -389,6 +389,15 @@ one track for the probe as a whole. Instants have no such restriction.
 A span keeps the track its entry opened, so a `scope:cpu` span whose
 thread migrates while it is open still ends on the CPU it began on.
 
+### Flow template
+
+`flow:<template>` or `flow:'template with spaces'`
+
+Connects related events across the trace with Perfetto flow arrows. The
+template renders to a *flow key* per event, and every event rendering
+the same key joins one flow, whatever probe, thread, process or CPU it
+came from. See **Flows** under **Perfetto rendering** below.
+
 ## Perfetto rendering
 
 Utrace events are captured in the context of the thread that was active
@@ -456,6 +465,32 @@ to a template. Captured argument values also appear as annotations on
 the Perfetto slice or instant event. An argument that could not be read
 is omitted from the annotations and renders empty in a template.
 
+**Flows:** A `flow:` template (same placeholder syntax as `name:`)
+renders to a string key per event, and events rendering equal keys are
+chained into one Perfetto flow, drawn as arrows between their slices and
+instants:
+
+```bash
+# arrow from where a work item was queued to where it ran
+-U 'raw_tp:workqueue_queue_work (arg:work/x) | flow:"work {work}" |'
+-U 'raw_tp:workqueue_execute_start (arg:work/x) | flow:"work {work}" |'
+```
+
+Flow keys share one trace-wide namespace: equal keys join across probes
+and processes. Keys that could collide by accident are disambiguated in
+the template itself — prefix a literal, or narrow with `{env:pid}` and
+friends when a value like a user-space pointer or an fd number is only
+unique within one process:
+
+```bash
+-U 'tp:syscalls:sys_enter_write (arg:fd) | flow:"{env:pid} fd {fd}" |'
+```
+
+A span's flow attaches at its entry; the exit neither renders the
+template nor needs to, as Perfetto draws a flow's outgoing arrow from
+the end of the slice. An exit with no entry to pair up with (see **Span
+rendering**) carries no flow either.
+
 **Capture environment:** A placeholder of the form `{env:...}` refers to
 the context the probe fired in rather than to an argument:
 
@@ -477,9 +512,9 @@ the context the probe fired in rather than to an argument:
 -U 'usdt:app:req_start (arg:0/name(req)) | name:"{env:comm} req {req}" |'
 ```
 
-These are available to both `name:` and `id:`, and unlike arguments they
-are available on every event, so a `name:` template built only from them
-also renders on span exit events. `env:` is a reserved namespace: an
+These are available to `name:`, `id:` and `flow:`, and unlike arguments
+they are available on every event, so a `name:` template built only from
+them also renders on span exit events. `env:` is a reserved namespace: an
 unknown key is rejected when the definition is parsed, whereas a
 placeholder naming no argument is left as literal text.
 
@@ -508,6 +543,10 @@ Event types: `utrace_instant`, `utrace_entry`, `utrace_exit`.
 `utrace_id` carries the rendered value when the `id:` setting is
 templated, so a span's entry and exit report the same one. An exit with
 no entry to pair up with reports the `id:` setting itself.
+
+`flow_id` carries the rendered `flow:` key when the probe has one, on
+`utrace_entry` and `utrace_instant` events only; exits don't render flow
+templates.
 
 Argument values are formatted by type: integers as decimal, pointers as
 `"0x..."` hex strings, strings as JSON strings. An argument whose value could

--- a/UTRACE.md
+++ b/UTRACE.md
@@ -344,12 +344,50 @@ placeholders. See **Perfetto rendering** below for details and examples.
 
 Sets a custom string identifier for the probe, used as `utrace_id` in
 JSON output instead of the default numeric index. Multiple probes
-sharing the same ID will have their events combined on the same
-per-thread track in Perfetto (see **Perfetto rendering** below).
+sharing the same ID will have their events combined on the same track
+in Perfetto (see **Perfetto rendering** below).
 
 Like `name:`, the identifier accepts `{...}` argument and `{env:...}`
 placeholders, in which case each distinct rendered value gets its own
 track.
+
+### Track scope
+
+`scope:thread` (the default), `scope:process`, `scope:cpu` or
+`scope:global`
+
+Chooses what a probe's tracks are grouped under. `id:` names the track;
+`scope:` says which container it lives in:
+
+| Scope     | Track lives under                                    |
+|-----------|------------------------------------------------------|
+| `thread`  | the thread the probe fired on                        |
+| `process` | the process the probe fired in                       |
+| `cpu`     | `CPU N` under the session's `CPUS` folder            |
+| `global`  | the session's `UTRACE` folder                        |
+
+```bash
+# one track per futex, carrying every thread of the process that contends on it
+-U 'tp:syscalls:sys_enter_futex (arg:uaddr/x) | scope:process, id:"futex {uaddr}" |'
+
+# where a kernel path runs, laid out per CPU
+-U 'kspan:submit_bio | scope:cpu |'
+```
+
+`id:` is optional: without one, each container gets a track named after
+the probe, the way a thread does at the default scope.
+
+Scope and `id:` are independent. Putting `{env:pid}` in an `id:` renames
+the track but leaves it under the thread; only `scope:` reparents it.
+
+A track wider than a thread can receive events from several threads at
+once. Perfetto requires the slices on one track to nest, so at these
+scopes an `id:` has to name something that is never concurrent with
+itself — one track per request, per queue or per connection, rather than
+one track for the probe as a whole. Instants have no such restriction.
+
+A span keeps the track its entry opened, so a `scope:cpu` span whose
+thread migrates while it is open still ends on the CPU it began on.
 
 ## Perfetto rendering
 
@@ -359,8 +397,9 @@ child track under the thread's scheduler track. The track is named after
 the probe target (e.g., `sched_switch`) or the custom `id:` setting.
 
 **Track grouping:** If multiple probes (whether instants, spans, or a
-mix) share the same `id:` value, all their events are rendered on the
-same per-thread child track. This is useful for grouping related probes:
+mix) share the same `id:` value (and the same `scope:`), all their
+events are rendered on the same track. This is useful for grouping
+related probes:
 
 ```bash
 # these two probes share a track per thread

--- a/UTRACE.md
+++ b/UTRACE.md
@@ -331,6 +331,13 @@ inherited by the second.
 
 Settings go inside `| ... |` after the parameters, comma-separated.
 
+### Name format template
+
+`name:<template>` or `name:'template with spaces'`
+
+Customizes event names with `{...}` argument placeholders. See
+**Perfetto rendering** below for details and examples.
+
 ### Custom probe ID
 
 `id:<identifier>` or `id:'identifier with spaces'`
@@ -340,12 +347,8 @@ JSON output instead of the default numeric index. Multiple probes
 sharing the same ID will have their events combined on the same
 per-thread track in Perfetto (see **Perfetto rendering** below).
 
-### Name format template
-
-`name:<template>` or `name:'template with spaces'`
-
-Customizes event names with `{...}` argument placeholders. See
-**Perfetto rendering** below for details and examples.
+Like `name:`, the identifier accepts `{...}` argument placeholders, in
+which case each distinct rendered value gets its own track.
 
 ## Perfetto rendering
 
@@ -364,9 +367,34 @@ same per-thread child track. This is useful for grouping related probes:
 -U 'k:mutex_unlock (arg:*) | id:locks |'
 ```
 
+**Tracks by argument value:** An `id:` with `{...}` placeholders (same
+syntax as `name:`, see **Event names** below) is rendered per event, and
+each distinct value gets its own per-thread track. This splits one probe
+across tracks by whatever its arguments identify:
+
+```bash
+# one track per (thread, ring) instead of a single track for the probe
+-U 'uspan:io_submit (arg:0.ring_id/name(ring)) | id:"ring {ring}" |'
+```
+
+Equal renderings share a track, across probes as well, so the grouping
+above is the case where every event renders the same string. A
+placeholder that matches no argument is left as is, and an id that
+substitutes nothing stays a single static track.
+
 **Span rendering:** Span probes (`uspan:`, `kspan:`, `bpfspan:`, and
 generic `~~` spans) produce Perfetto slices. The entry event starts the
 slice and the matching exit event ends it.
+
+A span's exit event carries only its own arguments (`arg:ret` for the
+native span probes, the exit leg's arguments for a generic `~~` span),
+so it can't re-render an `id:` template written against the entry
+arguments. It closes the track its own entry opened instead, matching
+exits to entries innermost-first for recursive spans. An exit with no
+entry to pair up with — a span already in flight when the capture (or
+the replay window) started — has no slice to close, so it is emitted as
+a standalone instant on the probe's own track, the one an untemplated
+`id:` would have used.
 
 **Event names:** By default, each event is labeled with the probe's
 target name (e.g., `process_request`, `sched_switch`). Use the `name:`
@@ -382,10 +410,11 @@ setting to customize this with argument substitution:
 
 Placeholders use `{...}` syntax and can reference arguments by their
 positional name (`{arg0}`) or by their display name (`{req_id}`,
-`{prev_comm}`). Both forms work if the argument has a name. Captured
-argument values also appear as annotations on the Perfetto slice or
-instant event. An argument that could not be read is omitted from the
-annotations and renders empty in a `name:` template.
+`{prev_comm}`). Both forms work if the argument has a name. Only
+entry-side arguments can be substituted, so `arg:ret` is not available
+to a template. Captured argument values also appear as annotations on
+the Perfetto slice or instant event. An argument that could not be read
+is omitted from the annotations and renders empty in a template.
 
 ## JSON output
 
@@ -404,6 +433,10 @@ With `-J`, utrace events appear as:
 ```
 
 Event types: `utrace_instant`, `utrace_entry`, `utrace_exit`.
+
+`utrace_id` carries the rendered value when the `id:` setting is
+templated, so a span's entry and exit report the same one. An exit with
+no entry to pair up with reports the `id:` setting itself.
 
 Argument values are formatted by type: integers as decimal, pointers as
 `"0x..."` hex strings, strings as JSON strings. An argument whose value could

--- a/src/data.c
+++ b/src/data.c
@@ -125,6 +125,12 @@ int process_events(struct worker_state *w, handle_event_fn *handlers, size_t han
 				event_kind_str(rec->e->kind), rec->e->kind, err);
 			return err; /* YEAH, I know about all the clean up, whatever */
 		}
+
+		/*
+		 * reset sfmt()'s thread-local state, invalidating all strings handed out by
+		 * sfmt() during event processing
+		 */
+		sfmt_reset();
 	}
 
 	return 0;

--- a/src/emit.c
+++ b/src/emit.c
@@ -4842,7 +4842,7 @@ static int utrace_render_env(char *buf, size_t buf_sz, const struct wevent *e,
 			     const struct wprof_task *t, enum utrace_env_ref ref)
 {
 	switch (ref) {
-	case UTRACE_ENV_TID:	return snprintf(buf, buf_sz, "%u", t->tid);
+	case UTRACE_ENV_TID:	return snprintf(buf, buf_sz, "%d", task_tid(t));
 	case UTRACE_ENV_PID:	return snprintf(buf, buf_sz, "%u", t->pid);
 	case UTRACE_ENV_PPID:	return snprintf(buf, buf_sz, "%u", t->ppid);
 	case UTRACE_ENV_COMM:	return snprintf(buf, buf_sz, "%s", t->comm);

--- a/src/emit.c
+++ b/src/emit.c
@@ -141,13 +141,14 @@ struct uscope_entry {
 };
 
 /*
- * A span exit event carries only its own (exit-leg) arguments, so it can't
- * re-render an id template written against entry arguments. The id its entry
- * rendered is remembered here instead, and matched back innermost-first.
+ * A span exit takes the track its entry opened: it carries no entry-side
+ * arguments to re-render a templated id from, and its thread may have migrated
+ * to another CPU meanwhile. The id the entry resolved is remembered here and
+ * matched back innermost-first.
  */
 struct utrace_open_span {
 	u32 cfg_id;			/* index of the utrace cfg the span belongs to */
-	u32 utrace_id;			/* id its entry rendered and opened a track with */
+	u32 utrace_id;			/* track id its entry resolved */
 };
 
 struct task_state {
@@ -195,14 +196,42 @@ static struct hashmap *tasks;
 static struct hashmap *emitted_descrs;
 
 /*
- * Ids from an id: setting continue the utrace_id space past the per-cfg ids
- * that -U positions define, so that they key tracks and JSON the same way a
- * cfg's own position does. Equal id strings intern to one id, and so share one
- * track, whether written literally or rendered from a template.
+ * A utrace_id identifies a track: the scope, the container within it, and the
+ * id: string (or the defining cfg, when there is none) intern to one dense id.
+ * Equal ids meet on one track whether written literally or rendered from a
+ * template, and everything a track needs rides on its id.
  */
-static struct hashmap *utrace_dyn_ids;	/* rendered id string -> utrace_id */
-static const char **utrace_dyn_names;	/* utrace_id - utrace_cfg_cnt -> rendered id string */
-static u32 utrace_dyn_cnt, utrace_dyn_cap;
+struct utrace_track {
+	enum utrace_scope scope;
+	u32 scope_id;		/* container: tid, pid, CPU, or 0 for global */
+	u32 cfg_id;		/* defining cfg, names the track and JSON when name is NULL */
+	const char *name;	/* interned id: string, NULL when the cfg has no id: */
+	u64 track_uuid;		/* assigned when the track descriptor is emitted, 0 before */
+};
+
+static struct hashmap *utrace_track_ids;	/* (scope, scope_id, name | cfg_id) -> utrace_id */
+static struct utrace_track *utrace_tracks;	/* utrace_id -> track; id 0 is reserved as "none" */
+static u32 utrace_track_next_id = 1;		/* id 0 is never handed out */
+static u32 utrace_track_cap;
+
+static size_t utrace_track_hash_fn(long id, void *ctx)
+{
+	const struct utrace_track *tr = &utrace_tracks[id];
+	size_t h = tr->name ? str_hash(tr->name) : tr->cfg_id;
+
+	return (h * 31 + tr->scope_id) * 31 + tr->scope;
+}
+
+static bool utrace_track_equal_fn(long a, long b, void *ctx)
+{
+	const struct utrace_track *x = &utrace_tracks[a], *y = &utrace_tracks[b];
+
+	if (x->scope != y->scope || x->scope_id != y->scope_id)
+		return false;
+	if (!x->name || !y->name)
+		return x->name == y->name && x->cfg_id == y->cfg_id;
+	return strcmp(x->name, y->name) == 0;
+}
 
 /*
  * Per (pmu_idx, cpu) snapshot of the previous PMU sample's absolute counter
@@ -232,6 +261,8 @@ enum track_kind {
 
 	TK_IDLE,		/* idle thread event track (by CPU), child of idle thread metadata */
 
+	TK_CPU,			/* per-CPU track (by CPU), child of the CPUS folder */
+
 	TK_SPECIAL,		/* special and fake groups (idle, kernel, requests, cuda, session) */
 
 	TK_DYNAMIC,		/* dynamically allocated track UUIDs (see enum dyn_track_kind) */
@@ -254,6 +285,9 @@ enum track_special {
 	TKS_CUDA = 5,
 
 	TKS_UNRESOLVED = 6,
+
+	TKS_UTRACE = 7,
+	TKS_CPUS = 8,
 };
 
 #define TRACK_UUID(kind, id) (((u64)(id) * TK_MULT) + (u64)kind)
@@ -264,6 +298,8 @@ enum track_special {
 #define TRACK_UUID_CUDA		TRACK_UUID(TK_SPECIAL, TKS_CUDA)
 #define TRACK_UUID_SESSION	TRACK_UUID(TK_SPECIAL, TKS_SESSION)
 #define TRACK_UUID_UNRESOLVED	TRACK_UUID(TK_SPECIAL, TKS_UNRESOLVED)
+#define TRACK_UUID_UTRACE	TRACK_UUID(TK_SPECIAL, TKS_UTRACE)
+#define TRACK_UUID_CPUS		TRACK_UUID(TK_SPECIAL, TKS_CPUS)
 
 enum dyn_track_kind {
 	__DTK_GAP = TK_MULT - 1,	/* we need to not overlap with enum track_kind */
@@ -295,7 +331,7 @@ enum dyn_track_kind {
 	DTK_THREAD_CUDA,		/* per-thread CUDA API calls track (id1 = tid) */
 	DTK_THREAD_CUDA_OVERHEAD,	/* per-thread CUDA/driver overhead track (id1 = tid) */
 	DTK_REQ_THREAD_EMBED,		/* first-event-per-thread tracking for embed mode (id1 = tid, id2 = req_id) */
-	DTK_UTRACE,			/* utrace per-config track (id1 = tid, id2 = utrace_id) */
+	DTK_UTRACE,			/* rank base for utrace tracks; they live in utrace_tracks[], not here */
 };
 
 struct track_key {
@@ -348,7 +384,6 @@ static size_t track_state_size(enum dyn_track_kind kind)
 	case DTK_REQ_THREAD_EMBED:
 	case DTK_PYTRACE:
 	case DTK_PYTORCH:
-	case DTK_UTRACE:
 	case DTK_TIMER:
 	case DTK_PMU_EVENT:
 	case DTK_CUDA_PROC:
@@ -490,8 +525,8 @@ int init_emit(struct worker_state *w)
 	if (!emitted_descrs)
 		return -ENOMEM;
 
-	utrace_dyn_ids = hashmap__new(str_hash_fn, str_equal_fn, NULL);
-	if (!utrace_dyn_ids)
+	utrace_track_ids = hashmap__new(utrace_track_hash_fn, utrace_track_equal_fn, NULL);
+	if (!utrace_track_ids)
 		return -ENOMEM;
 
 	cur_wpb_writer = w->wpb_writer;
@@ -1382,7 +1417,7 @@ static struct task_state *task_state(struct worker_state *w, const struct wprof_
 	return st;
 }
 
-enum { TDK_THREAD = 0, TDK_PROCESS = 1, TDK_THREAD_IDLE = 2 };
+enum { TDK_THREAD = 0, TDK_PROCESS = 1, TDK_THREAD_IDLE = 2, TDK_CPU = 3 };
 
 static bool track_descr_emitted(int kind, u32 id)
 {
@@ -1394,6 +1429,23 @@ static void track_descr_mark_emitted(int kind, u32 id)
 {
 	unsigned long key = (unsigned long)kind << 32 | id;
 	hashmap__set(emitted_descrs, key, (void *)1, NULL, NULL);
+}
+
+/* per-CPU track under the session's CPUS folder, both created on first use */
+static u64 trackid_cpu(u32 cpu)
+{
+	static bool cpus_folder;
+	u64 track_id = TRACK_UUID(TK_CPU, cpu);
+
+	if (!track_descr_emitted(TDK_CPU, cpu)) {
+		track_descr_mark_emitted(TDK_CPU, cpu);
+		if (!cpus_folder) {
+			emit_track_descr_explicit(TRACK_UUID_CPUS, TRACK_UUID_SESSION, "CPUS", TKS_CPUS);
+			cpus_folder = true;
+		}
+		emit_track_descr(track_id, TRACK_UUID_CPUS, sfmt("CPU %u", cpu), cpu);
+	}
+	return track_id;
 }
 
 static void emit_track_descrs(struct worker_state *w, const struct wprof_task *t)
@@ -4609,53 +4661,77 @@ static const char *utrace_probe_name(const struct utrace_cfg *cfg)
 	}
 }
 
-static bool utrace_id_is_dyn(u32 utrace_id)
+static u32 utrace_intern_track(enum utrace_scope scope, u32 scope_id, const char *name, u32 cfg_id)
 {
-	return utrace_id >= env.utrace_cfg_cnt;
-}
-
-static const char *utrace_dyn_name(u32 utrace_id)
-{
-	return utrace_dyn_names[utrace_id - env.utrace_cfg_cnt];
-}
-
-static u32 utrace_intern_id(const char *name)
-{
-	long id;
-
-	if (hashmap__find(utrace_dyn_ids, name, &id))
-		return id;
-
-	if (utrace_dyn_cnt == utrace_dyn_cap) {
-		utrace_dyn_cap = utrace_dyn_cap ? utrace_dyn_cap * 2 : 16;
-		utrace_dyn_names = realloc(utrace_dyn_names, utrace_dyn_cap * sizeof(*utrace_dyn_names));
+	if (!utrace_tracks) {
+		utrace_track_cap = 16;
+		utrace_tracks = calloc(utrace_track_cap, sizeof(*utrace_tracks));
+	} else if (utrace_track_next_id == utrace_track_cap) {
+		utrace_track_cap *= 2;
+		utrace_tracks = realloc(utrace_tracks, utrace_track_cap * sizeof(*utrace_tracks));
 	}
 
-	u32 utrace_id = env.utrace_cfg_cnt + utrace_dyn_cnt;
-	const char *key = strdup(name);
+	/* stage the candidate at the next id, where the hashmap callbacks see it */
+	struct utrace_track *tr = &utrace_tracks[utrace_track_next_id];
+	long id;
 
-	utrace_dyn_names[utrace_dyn_cnt++] = key;
-	hashmap__add(utrace_dyn_ids, key, utrace_id);
+	*tr = (struct utrace_track){ .scope = scope, .scope_id = scope_id, .cfg_id = cfg_id, .name = name };
+	if (hashmap__find(utrace_track_ids, utrace_track_next_id, &id))
+		return id;
 
-	return utrace_id;
+	if (name)
+		tr->name = strdup(name);
+	hashmap__add(utrace_track_ids, utrace_track_next_id, utrace_track_next_id);
+
+	return utrace_track_next_id++;
 }
 
-static u64 ensure_utrace_thread_track(const struct wprof_task *t, u32 utrace_id)
+static u32 utrace_scope_id(enum utrace_scope scope, const struct wprof_task *t, const struct wevent *e)
 {
-	struct track_state *s = track_state_get_or_add(DTK_UTRACE, t->tid, utrace_id);
+	switch (scope) {
+	case UTRACE_SCOPE_THREAD:	return t->tid;
+	case UTRACE_SCOPE_PROCESS:	return t->pid;
+	case UTRACE_SCOPE_CPU:		return e->cpu;
+	case UTRACE_SCOPE_GLOBAL:	return 0;
+	default:			BUG("unexpected utrace scope in utrace_scope_id(): %d\n", scope);
+	}
+}
 
-	if (!s->exists) {
+static u64 utrace_scope_parent(enum utrace_scope scope, const struct wprof_task *t, u32 scope_id)
+{
+	static bool utrace_folder;
+
+	switch (scope) {
+	case UTRACE_SCOPE_THREAD:
+		return trackid_thread(t);
+	case UTRACE_SCOPE_PROCESS:
+		return trackid_process(t);
+	case UTRACE_SCOPE_CPU:
+		return trackid_cpu(scope_id);
+	case UTRACE_SCOPE_GLOBAL:
+		if (!utrace_folder) {
+			emit_track_descr_explicit(TRACK_UUID_UTRACE, TRACK_UUID_SESSION, "UTRACE", TKS_UTRACE);
+			utrace_folder = true;
+		}
+		return TRACK_UUID_UTRACE;
+	default:
+		BUG("unexpected utrace scope in utrace_scope_parent(): %d\n", scope);
+	}
+}
+
+static u64 ensure_utrace_track(const struct wprof_task *t, u32 utrace_id)
+{
+	struct utrace_track *tr = &utrace_tracks[utrace_id];
+
+	if (!tr->track_uuid) {
+		tr->track_uuid = TRACK_UUID(TK_DYNAMIC, dyn_track_next_id++);
+
 		char span_name[256];
-		const char *name;
+		const char *name = tr->name;
+		if (!name) {
+			const struct utrace_cfg *cfg = &env.utrace_cfgs[tr->cfg_id];
 
-		if (utrace_id_is_dyn(utrace_id)) {
-			name = utrace_dyn_name(utrace_id);
-		} else {
-			const struct utrace_cfg *cfg = &env.utrace_cfgs[utrace_id];
-
-			if (cfg->settings.id) {
-				name = cfg->settings.id;
-			} else if (cfg->type == UTRACE_SPAN) {
+			if (cfg->type == UTRACE_SPAN) {
 				snprintf(span_name, sizeof(span_name), "%s — %s",
 					 utrace_probe_name(cfg->span.entry), utrace_probe_name(cfg->span.exit));
 				name = span_name;
@@ -4664,10 +4740,10 @@ static u64 ensure_utrace_thread_track(const struct wprof_task *t, u32 utrace_id)
 			}
 		}
 
-		emit_track_descr(s->track_id, trackid_thread(t), name, s->kind + utrace_id);
-		s->exists = true;
+		emit_track_descr(tr->track_uuid, utrace_scope_parent(tr->scope, t, tr->scope_id),
+				 name, DTK_UTRACE + utrace_id);
 	}
-	return s->track_id;
+	return tr->track_uuid;
 }
 
 static s64 read_int_blob(struct wprof_data_hdr *hdr, u32 bloboff, enum utrace_arg_type type)
@@ -4811,11 +4887,11 @@ static void utrace_span_push(struct task_state *st, u32 cfg_id, u32 utrace_id)
 }
 
 /*
- * Take back the id of the innermost span of this cfg still open on the thread.
- * Spans of different cfgs can interleave, so this isn't always the top entry.
- * Returns -1 if the thread has no such span open.
+ * Take back what the innermost span of this cfg still open on the thread
+ * resolved to. Spans of different cfgs can interleave, so this isn't always the
+ * top entry. Returns 0 if the thread has no such span open.
  */
-static int utrace_span_pop(struct task_state *st, u32 cfg_id)
+static u32 utrace_span_pop(struct task_state *st, u32 cfg_id)
 {
 	for (int i = st->utspan_cnt - 1; i >= 0; i--) {
 		if (st->utspans[i].cfg_id != cfg_id)
@@ -4828,32 +4904,34 @@ static int utrace_span_pop(struct task_state *st, u32 cfg_id)
 		st->utspan_cnt--;
 		return utrace_id;
 	}
-	return -1;
+	return 0;
 }
 
 /*
- * Resolve the utrace id an event's track and JSON id are keyed by: the interned
- * id: setting, rendered first if it is templated, or the cfg's own position
- * when it has no id:. Returns -1 for the exit of a span that was already open
- * when the capture (or the replay window) started, as the id its entry would
- * have rendered is unknown.
+ * Resolve the utrace id of the track an event belongs on: the id: setting,
+ * rendered first if it is templated, under the container of the cfg's scope. A
+ * span's exit takes back what its entry resolved. Returns 0 for the exit of a
+ * span that was already open when the capture (or the replay window) started,
+ * as what its entry resolved to is unknown.
  */
-static int utrace_event_id(struct worker_state *w, const struct wevent *e,
+static u32 utrace_event_id(struct worker_state *w, const struct wevent *e,
 			   const struct utrace_cfg *cfg, const struct wprof_task *t, int arg_cnt)
 {
 	u32 cfg_id = e->utrace.utrace_id;
+	const char *name = cfg->settings.id;
 	char buf[256];
 	u32 utrace_id;
-
-	if (!cfg->settings.id_segs)
-		return cfg->settings.id ? utrace_intern_id(cfg->settings.id) : cfg_id;
 
 	if (e->kind == EV_UTRACE_EXIT)
 		return utrace_span_pop(task_state(w, t), cfg_id);
 
-	utrace_render_tmpl(buf, sizeof(buf), w->dump_hdr, e, t, cfg->settings.id_segs,
-			   cfg->settings.id_seg_cnt, arg_cnt);
-	utrace_id = utrace_intern_id(buf);
+	if (cfg->settings.id_segs) {
+		utrace_render_tmpl(buf, sizeof(buf), w->dump_hdr, e, t, cfg->settings.id_segs,
+				   cfg->settings.id_seg_cnt, arg_cnt);
+		name = buf;
+	}
+	utrace_id = utrace_intern_track(cfg->settings.scope,
+					utrace_scope_id(cfg->settings.scope, t, e), name, cfg_id);
 
 	if (e->kind == EV_UTRACE_ENTRY)
 		utrace_span_push(task_state(w, t), cfg_id, utrace_id);
@@ -4916,7 +4994,7 @@ static void emit_utrace_event(struct worker_state *w, const struct wevent *e)
 			arg_cnt++;
 	}
 
-	int utrace_id = utrace_event_id(w, e, cfg, &task, arg_cnt);
+	u32 utrace_id = utrace_event_id(w, e, cfg, &task, arg_cnt);
 	enum event_kind emit_kind = e->kind;
 
 	/*
@@ -4924,13 +5002,15 @@ static void emit_utrace_event(struct worker_state *w, const struct wevent *e)
 	 * to the cfg's own track as a standalone instant, as an untemplated id
 	 * would have put it.
 	 */
-	if (utrace_id < 0) {
-		utrace_id = cfg_id;
+	if (!utrace_id) {
+		utrace_id = utrace_intern_track(cfg->settings.scope,
+						utrace_scope_id(cfg->settings.scope, &task, e),
+						cfg->settings.id, cfg_id);
 		emit_kind = EV_UTRACE_INSTANT;
 	}
 
 	emit_track_descrs(w, &task);
-	u64 track_uuid = ensure_utrace_thread_track(&task, utrace_id);
+	u64 track_uuid = ensure_utrace_track(&task, utrace_id);
 
 	/* Format the event name: use name_tmpl unless it needs the entry-side args an exit lacks */
 	char name_buf[256];
@@ -5004,16 +5084,14 @@ static void emit_utrace_json(struct worker_state *w, const struct wevent *e)
 	}
 
 	/* Emit formatted name and probe id */
-	int utrace_id = utrace_event_id(w, e, cfg, &task, arg_cnt);
-	if (utrace_id < 0)
-		utrace_id = cfg_id;
-	if (utrace_id_is_dyn(utrace_id)) {
-		json_kv_str(j, "utrace_id", utrace_dyn_name(utrace_id));
-	} else if (cfg->settings.id) {
-		json_kv_str(j, "utrace_id", cfg->settings.id);
+	u32 utrace_id = utrace_event_id(w, e, cfg, &task, arg_cnt);
+	const char *id_str = utrace_id ? utrace_tracks[utrace_id].name : cfg->settings.id;
+
+	if (id_str) {
+		json_kv_str(j, "utrace_id", id_str);
 	} else {
 		char id_buf[16];
-		snprintf(id_buf, sizeof(id_buf), "%u", utrace_id);
+		snprintf(id_buf, sizeof(id_buf), "%u", cfg_id);
 		json_kv_str(j, "utrace_id", id_buf);
 	}
 	char name_buf[256];

--- a/src/emit.c
+++ b/src/emit.c
@@ -195,10 +195,10 @@ static struct hashmap *tasks;
 static struct hashmap *emitted_descrs;
 
 /*
- * Ids rendered from a templated id: setting continue the utrace_id space past
- * the per-cfg ids that -U positions define, so that a rendered id keys tracks
- * and JSON the same way a cfg's own id does. Equal renderings intern to one id,
- * and so share one track, across cfgs as well.
+ * Ids from an id: setting continue the utrace_id space past the per-cfg ids
+ * that -U positions define, so that they key tracks and JSON the same way a
+ * cfg's own position does. Equal id strings intern to one id, and so share one
+ * track, whether written literally or rendered from a template.
  */
 static struct hashmap *utrace_dyn_ids;	/* rendered id string -> utrace_id */
 static const char **utrace_dyn_names;	/* utrace_id - utrace_cfg_cnt -> rendered id string */
@@ -4832,11 +4832,11 @@ static int utrace_span_pop(struct task_state *st, u32 cfg_id)
 }
 
 /*
- * Resolve the utrace id an event's track and JSON id are keyed by: the cfg's
- * own id, unless its id: setting is templated, in which case the id rendered
- * from the event's arguments. Returns -1 for the exit of a span that was
- * already open when the capture (or the replay window) started, as the id its
- * entry would have rendered is unknown.
+ * Resolve the utrace id an event's track and JSON id are keyed by: the interned
+ * id: setting, rendered first if it is templated, or the cfg's own position
+ * when it has no id:. Returns -1 for the exit of a span that was already open
+ * when the capture (or the replay window) started, as the id its entry would
+ * have rendered is unknown.
  */
 static int utrace_event_id(struct worker_state *w, const struct wevent *e,
 			   const struct utrace_cfg *cfg, const struct wprof_task *t, int arg_cnt)
@@ -4846,7 +4846,7 @@ static int utrace_event_id(struct worker_state *w, const struct wevent *e,
 	u32 utrace_id;
 
 	if (!cfg->settings.id_segs)
-		return cfg_id;
+		return cfg->settings.id ? utrace_intern_id(cfg->settings.id) : cfg_id;
 
 	if (e->kind == EV_UTRACE_EXIT)
 		return utrace_span_pop(task_state(w, t), cfg_id);

--- a/src/emit.c
+++ b/src/emit.c
@@ -5009,6 +5009,24 @@ static void emit_utrace_args(struct worker_state *w, const struct wevent *e,
 	}
 }
 
+static void emit_utrace_anns(struct worker_state *w, const struct wevent *e, const struct wprof_task *t,
+			      const struct utrace_cfg *cfg, int arg_cnt)
+{
+	for (int i = 0; i < cfg->settings.ann_cnt; i++) {
+		const struct utrace_ann *ann = &cfg->settings.anns[i];
+		char buf[256];
+
+		if (e->kind == EV_UTRACE_EXIT && ann->has_args)
+			continue;
+
+		utrace_render_tmpl(buf, sizeof(buf), w->dump_hdr, e, t, ann->segs, ann->seg_cnt, arg_cnt);
+
+		struct pb_str name = iid_str(emit_intern_str(w, ann->name), ann->name);
+
+		emit_kv_str(name, sfmt("%s", buf));
+	}
+}
+
 static void emit_utrace_event(struct worker_state *w, const struct wevent *e)
 {
 	struct wprof_data_hdr *hdr = w->dump_hdr;
@@ -5066,6 +5084,7 @@ static void emit_utrace_event(struct worker_state *w, const struct wevent *e)
 	case EV_UTRACE_ENTRY:
 		emit_slice_begin(track_uuid, e->ts, iid_str(name_iid, name), IID_CAT_UTRACE) {
 			emit_utrace_args(w, e, arg_cfg, arg_cnt, ret_filter);
+			emit_utrace_anns(w, e, &task, cfg, arg_cnt);
 			if (stack_id > 0)
 				emit_callstack(w, stack_id);
 			if (flow_id)
@@ -5075,6 +5094,7 @@ static void emit_utrace_event(struct worker_state *w, const struct wevent *e)
 	case EV_UTRACE_EXIT:
 		emit_slice_end(track_uuid, e->ts, iid_str(name_iid, name), IID_CAT_UTRACE) {
 			emit_utrace_args(w, e, arg_cfg, arg_cnt, ret_filter);
+			emit_utrace_anns(w, e, &task, cfg, arg_cnt);
 			if (stack_id > 0)
 				emit_callstack(w, stack_id);
 		}
@@ -5082,6 +5102,7 @@ static void emit_utrace_event(struct worker_state *w, const struct wevent *e)
 	default: /* EV_UTRACE_INSTANT */
 		emit_instant(track_uuid, e->ts, iid_str(name_iid, name), IID_CAT_UTRACE) {
 			emit_utrace_args(w, e, arg_cfg, arg_cnt, ret_filter);
+			emit_utrace_anns(w, e, &task, cfg, arg_cnt);
 			if (stack_id > 0)
 				emit_callstack(w, stack_id);
 			if (flow_id)
@@ -5195,6 +5216,23 @@ static void emit_utrace_json(struct worker_state *w, const struct wevent *e)
 		}
 		json_obj_end(j);
 	}
+
+	bool has_anns = false;
+	for (int i = 0; i < cfg->settings.ann_cnt; i++) {
+		const struct utrace_ann *ann = &cfg->settings.anns[i];
+		char abuf[256];
+
+		if (e->kind == EV_UTRACE_EXIT && ann->has_args)
+			continue;
+		if (!has_anns)
+			json_subobj_start(j, "anns");
+		has_anns = true;
+
+		utrace_render_tmpl(abuf, sizeof(abuf), hdr, e, &task, ann->segs, ann->seg_cnt, arg_cnt);
+		json_kv_str(j, ann->name, abuf);
+	}
+	if (has_anns)
+		json_obj_end(j);
 
 	if ((env.requested_stack_traces & ST_UTRACE) && e->utrace.utrace_stack_id > 0)
 		json_kv_int(j, "stack_id", e->utrace.utrace_stack_id);

--- a/src/emit.c
+++ b/src/emit.c
@@ -4678,11 +4678,11 @@ static bool utrace_arg_for_event(const struct wevent *e, bool ret_filter, const 
 }
 
 /*
- * Format a utrace event name using cfg->settings.name_fmt, substituting
+ * Format a utrace event name using cfg->settings.name_tmpl, substituting
  * {arg_name} placeholders with actual argument values. Only entry-side args
  * (non-ret) are available for substitution. Returns length written (like snprintf).
  */
-static int format_utrace_name(char *buf, size_t buf_sz, struct wprof_data_hdr *hdr,
+static int utrace_render_name(char *buf, size_t buf_sz, struct wprof_data_hdr *hdr,
 			      const struct wevent *e, const struct utrace_cfg *cfg, int arg_cnt)
 {
 	if (!cfg->settings.name_segs)
@@ -4692,10 +4692,10 @@ static int format_utrace_name(char *buf, size_t buf_sz, struct wprof_data_hdr *h
 	size_t pos = 0;
 
 	for (int i = 0; i < cfg->settings.name_seg_cnt && pos < buf_sz - 1; i++) {
-		const struct utrace_fmt_seg *seg = &cfg->settings.name_segs[i];
+		const struct utrace_tmpl_seg *seg = &cfg->settings.name_segs[i];
 		int n = 0;
 
-		if (seg->type == UTRACE_FMT_SEG_LIT) {
+		if (seg->type == UTRACE_TMPL_SEG_LIT) {
 			n = snprintf(buf + pos, buf_sz - pos, "%.*s", seg->lit.len, seg->lit.s);
 		} else if (seg->arg.arg_idx < arg_cnt && arg_refs[seg->arg.arg_idx] >= 0) {
 			n = utrace_format_arg(buf + pos, buf_sz - pos, hdr, arg_refs[seg->arg.arg_idx],
@@ -4767,11 +4767,11 @@ static void emit_utrace_event(struct worker_state *w, const struct wevent *e)
 			arg_cnt++;
 	}
 
-	/* Format the event name: use name_fmt on entry/instant, probe name on exit */
+	/* Format the event name: use name_tmpl on entry/instant, probe name on exit */
 	char name_buf[256];
 	const char *name;
 	if (e->kind != EV_UTRACE_EXIT && cfg->settings.name_segs) {
-		format_utrace_name(name_buf, sizeof(name_buf), hdr, e, cfg, arg_cnt);
+		utrace_render_name(name_buf, sizeof(name_buf), hdr, e, cfg, arg_cnt);
 		name = name_buf;
 	} else {
 		name = utrace_probe_name(arg_cfg);
@@ -4849,7 +4849,7 @@ static void emit_utrace_json(struct worker_state *w, const struct wevent *e)
 	char name_buf[256];
 	const char *name;
 	if (e->kind != EV_UTRACE_EXIT && cfg->settings.name_segs) {
-		format_utrace_name(name_buf, sizeof(name_buf), hdr, e, cfg, arg_cnt);
+		utrace_render_name(name_buf, sizeof(name_buf), hdr, e, cfg, arg_cnt);
 		name = name_buf;
 	} else {
 		name = utrace_probe_name(arg_cfg);

--- a/src/emit.c
+++ b/src/emit.c
@@ -140,6 +140,16 @@ struct uscope_entry {
 	enum uscope_state state;
 };
 
+/*
+ * A span exit event carries only its own (exit-leg) arguments, so it can't
+ * re-render an id template written against entry arguments. The id its entry
+ * rendered is remembered here instead, and matched back innermost-first.
+ */
+struct utrace_open_span {
+	u32 cfg_id;			/* index of the utrace cfg the span belongs to */
+	u32 utrace_id;			/* id its entry rendered and opened a track with */
+};
+
 struct task_state {
 	int tid, pid;
 	pb_iid name_iid;
@@ -176,10 +186,23 @@ struct task_state {
 	int pytorch_depth;
 	struct uscope_entry *uscope;
 	int uscope_cnt, uscope_cap;
+	/* utrace spans with a templated id that are open on this thread */
+	struct utrace_open_span *utspans;
+	int utspan_cnt, utspan_cap;
 };
 
 static struct hashmap *tasks;
 static struct hashmap *emitted_descrs;
+
+/*
+ * Ids rendered from a templated id: setting continue the utrace_id space past
+ * the per-cfg ids that -U positions define, so that a rendered id keys tracks
+ * and JSON the same way a cfg's own id does. Equal renderings intern to one id,
+ * and so share one track, across cfgs as well.
+ */
+static struct hashmap *utrace_dyn_ids;	/* rendered id string -> utrace_id */
+static const char **utrace_dyn_names;	/* utrace_id - utrace_cfg_cnt -> rendered id string */
+static u32 utrace_dyn_cnt, utrace_dyn_cap;
 
 /*
  * Per (pmu_idx, cpu) snapshot of the previous PMU sample's absolute counter
@@ -465,6 +488,10 @@ int init_emit(struct worker_state *w)
 
 	emitted_descrs = hashmap__new(hash_identity_fn, hash_equal_fn, NULL);
 	if (!emitted_descrs)
+		return -ENOMEM;
+
+	utrace_dyn_ids = hashmap__new(str_hash_fn, str_equal_fn, NULL);
+	if (!utrace_dyn_ids)
 		return -ENOMEM;
 
 	cur_wpb_writer = w->wpb_writer;
@@ -1414,6 +1441,7 @@ static void task_state_delete(struct wprof_task *t)
 
 	if (hashmap__delete(tasks, key, NULL, &st)) {
 		free(st->uscope);
+		free(st->utspans);
 		free(st);
 	}
 }
@@ -4581,23 +4609,59 @@ static const char *utrace_probe_name(const struct utrace_cfg *cfg)
 	}
 }
 
+static bool utrace_id_is_dyn(u32 utrace_id)
+{
+	return utrace_id >= env.utrace_cfg_cnt;
+}
+
+static const char *utrace_dyn_name(u32 utrace_id)
+{
+	return utrace_dyn_names[utrace_id - env.utrace_cfg_cnt];
+}
+
+static u32 utrace_intern_id(const char *name)
+{
+	long id;
+
+	if (hashmap__find(utrace_dyn_ids, name, &id))
+		return id;
+
+	if (utrace_dyn_cnt == utrace_dyn_cap) {
+		utrace_dyn_cap = utrace_dyn_cap ? utrace_dyn_cap * 2 : 16;
+		utrace_dyn_names = realloc(utrace_dyn_names, utrace_dyn_cap * sizeof(*utrace_dyn_names));
+	}
+
+	u32 utrace_id = env.utrace_cfg_cnt + utrace_dyn_cnt;
+	const char *key = strdup(name);
+
+	utrace_dyn_names[utrace_dyn_cnt++] = key;
+	hashmap__add(utrace_dyn_ids, key, utrace_id);
+
+	return utrace_id;
+}
+
 static u64 ensure_utrace_thread_track(const struct wprof_task *t, u32 utrace_id)
 {
 	struct track_state *s = track_state_get_or_add(DTK_UTRACE, t->tid, utrace_id);
 
 	if (!s->exists) {
-		const struct utrace_cfg *cfg = &env.utrace_cfgs[utrace_id];
 		char span_name[256];
 		const char *name;
 
-		if (cfg->settings.id) {
-			name = cfg->settings.id;
-		} else if (cfg->type == UTRACE_SPAN) {
-			snprintf(span_name, sizeof(span_name), "%s — %s",
-				 utrace_probe_name(cfg->span.entry), utrace_probe_name(cfg->span.exit));
-			name = span_name;
+		if (utrace_id_is_dyn(utrace_id)) {
+			name = utrace_dyn_name(utrace_id);
 		} else {
-			name = utrace_probe_name(cfg);
+			const struct utrace_cfg *cfg = &env.utrace_cfgs[utrace_id];
+
+			if (cfg->settings.id) {
+				name = cfg->settings.id;
+			} else if (cfg->type == UTRACE_SPAN) {
+				snprintf(span_name, sizeof(span_name), "%s — %s",
+					 utrace_probe_name(cfg->span.entry), utrace_probe_name(cfg->span.exit));
+				name = span_name;
+			} else {
+				name = utrace_probe_name(cfg);
+			}
 		}
 
 		emit_track_descr(s->track_id, trackid_thread(t), name, s->kind + utrace_id);
@@ -4678,21 +4742,19 @@ static bool utrace_arg_for_event(const struct wevent *e, bool ret_filter, const 
 }
 
 /*
- * Format a utrace event name using cfg->settings.name_tmpl, substituting
- * {arg_name} placeholders with actual argument values. Only entry-side args
- * (non-ret) are available for substitution. Returns length written (like snprintf).
+ * Format a compiled template, substituting {arg_name} placeholders with actual
+ * argument values. Only entry-side args (non-ret) are available for
+ * substitution. Returns length written (like snprintf).
  */
-static int utrace_render_name(char *buf, size_t buf_sz, struct wprof_data_hdr *hdr,
-			      const struct wevent *e, const struct utrace_cfg *cfg, int arg_cnt)
+static int utrace_render_tmpl(char *buf, size_t buf_sz, struct wprof_data_hdr *hdr,
+			      const struct wevent *e, const struct utrace_tmpl_seg *segs, int seg_cnt,
+			      int arg_cnt)
 {
-	if (!cfg->settings.name_segs)
-		return snprintf(buf, buf_sz, "%s", utrace_probe_name(cfg));
-
 	const s32 *arg_refs = (const s32 *)((const void *)e + WEVENT_SZ(utrace));
 	size_t pos = 0;
 
-	for (int i = 0; i < cfg->settings.name_seg_cnt && pos < buf_sz - 1; i++) {
-		const struct utrace_tmpl_seg *seg = &cfg->settings.name_segs[i];
+	for (int i = 0; i < seg_cnt && pos < buf_sz - 1; i++) {
+		const struct utrace_tmpl_seg *seg = &segs[i];
 		int n = 0;
 
 		if (seg->type == UTRACE_TMPL_SEG_LIT) {
@@ -4707,6 +4769,77 @@ static int utrace_render_name(char *buf, size_t buf_sz, struct wprof_data_hdr *h
 
 	buf[pos] = '\0';
 	return pos;
+}
+
+static int utrace_render_name(char *buf, size_t buf_sz, struct wprof_data_hdr *hdr,
+			      const struct wevent *e, const struct utrace_cfg *cfg, int arg_cnt)
+{
+	if (cfg->settings.name_segs) {
+		return utrace_render_tmpl(buf, buf_sz, hdr, e, cfg->settings.name_segs,
+					  cfg->settings.name_seg_cnt, arg_cnt);
+	} else {
+		return snprintf(buf, buf_sz, "%s", utrace_probe_name(cfg));
+	}
+}
+
+static void utrace_span_push(struct task_state *st, u32 cfg_id, u32 utrace_id)
+{
+	if (st->utspan_cnt == st->utspan_cap) {
+		st->utspan_cap = st->utspan_cap ? st->utspan_cap * 2 : 8;
+		st->utspans = realloc(st->utspans, st->utspan_cap * sizeof(*st->utspans));
+	}
+	st->utspans[st->utspan_cnt++] = (struct utrace_open_span){ .cfg_id = cfg_id, .utrace_id = utrace_id };
+}
+
+/*
+ * Take back the id of the innermost span of this cfg still open on the thread.
+ * Spans of different cfgs can interleave, so this isn't always the top entry.
+ * Returns -1 if the thread has no such span open.
+ */
+static int utrace_span_pop(struct task_state *st, u32 cfg_id)
+{
+	for (int i = st->utspan_cnt - 1; i >= 0; i--) {
+		if (st->utspans[i].cfg_id != cfg_id)
+			continue;
+
+		u32 utrace_id = st->utspans[i].utrace_id;
+
+		memmove(&st->utspans[i], &st->utspans[i + 1],
+			(st->utspan_cnt - i - 1) * sizeof(*st->utspans));
+		st->utspan_cnt--;
+		return utrace_id;
+	}
+	return -1;
+}
+
+/*
+ * Resolve the utrace id an event's track and JSON id are keyed by: the cfg's
+ * own id, unless its id: setting is templated, in which case the id rendered
+ * from the event's arguments. Returns -1 for the exit of a span that was
+ * already open when the capture (or the replay window) started, as the id its
+ * entry would have rendered is unknown.
+ */
+static int utrace_event_id(struct worker_state *w, const struct wevent *e,
+			   const struct utrace_cfg *cfg, const struct wprof_task *t, int arg_cnt)
+{
+	u32 cfg_id = e->utrace.utrace_id;
+	char buf[256];
+	u32 utrace_id;
+
+	if (!cfg->settings.id_segs)
+		return cfg_id;
+
+	if (e->kind == EV_UTRACE_EXIT)
+		return utrace_span_pop(task_state(w, t), cfg_id);
+
+	utrace_render_tmpl(buf, sizeof(buf), w->dump_hdr, e, cfg->settings.id_segs,
+			   cfg->settings.id_seg_cnt, arg_cnt);
+	utrace_id = utrace_intern_id(buf);
+
+	if (e->kind == EV_UTRACE_ENTRY)
+		utrace_span_push(task_state(w, t), cfg_id, utrace_id);
+
+	return utrace_id;
 }
 
 static void emit_utrace_args(struct worker_state *w, const struct wevent *e,
@@ -4752,13 +4885,10 @@ static void emit_utrace_event(struct worker_state *w, const struct wevent *e)
 	struct wprof_data_hdr *hdr = w->dump_hdr;
 	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
 
-	u32 utrace_id = e->utrace.utrace_id;
-	const struct utrace_cfg *cfg = &env.utrace_cfgs[utrace_id];
+	u32 cfg_id = e->utrace.utrace_id;
+	const struct utrace_cfg *cfg = &env.utrace_cfgs[cfg_id];
 	bool ret_filter;
 	const struct utrace_cfg *arg_cfg = utrace_arg_cfg(e, &ret_filter);
-
-	emit_track_descrs(w, &task);
-	u64 track_uuid = ensure_utrace_thread_track(&task, utrace_id);
 
 	/* Count args for this event side */
 	int arg_cnt = 0;
@@ -4766,6 +4896,22 @@ static void emit_utrace_event(struct worker_state *w, const struct wevent *e)
 		if (utrace_arg_for_event(e, ret_filter, &arg_cfg->params[i]))
 			arg_cnt++;
 	}
+
+	int utrace_id = utrace_event_id(w, e, cfg, &task, arg_cnt);
+	enum event_kind emit_kind = e->kind;
+
+	/*
+	 * An exit with no entry to pair up with has no slice to close, so it goes
+	 * to the cfg's own track as a standalone instant, as an untemplated id
+	 * would have put it.
+	 */
+	if (utrace_id < 0) {
+		utrace_id = cfg_id;
+		emit_kind = EV_UTRACE_INSTANT;
+	}
+
+	emit_track_descrs(w, &task);
+	u64 track_uuid = ensure_utrace_thread_track(&task, utrace_id);
 
 	/* Format the event name: use name_tmpl on entry/instant, probe name on exit */
 	char name_buf[256];
@@ -4780,7 +4926,7 @@ static void emit_utrace_event(struct worker_state *w, const struct wevent *e)
 
 	u32 stack_id = (env.requested_stack_traces & ST_UTRACE) ? e->utrace.utrace_stack_id : 0;
 
-	switch (e->kind) {
+	switch (emit_kind) {
 	case EV_UTRACE_ENTRY:
 		emit_slice_begin(track_uuid, e->ts, iid_str(name_iid, name), IID_CAT_UTRACE) {
 			emit_utrace_args(w, e, arg_cfg, arg_cnt, ret_filter);
@@ -4811,8 +4957,8 @@ static void emit_utrace_json(struct worker_state *w, const struct wevent *e)
 	struct wprof_data_hdr *hdr = w->dump_hdr;
 	struct wprof_task task = wevent_resolve_task(hdr, e->task_id);
 
-	u32 utrace_id = e->utrace.utrace_id;
-	const struct utrace_cfg *cfg = &env.utrace_cfgs[utrace_id];
+	u32 cfg_id = e->utrace.utrace_id;
+	const struct utrace_cfg *cfg = &env.utrace_cfgs[cfg_id];
 	bool ret_filter;
 	const struct utrace_cfg *arg_cfg = utrace_arg_cfg(e, &ret_filter);
 
@@ -4839,7 +4985,12 @@ static void emit_utrace_json(struct worker_state *w, const struct wevent *e)
 	}
 
 	/* Emit formatted name and probe id */
-	if (cfg->settings.id) {
+	int utrace_id = utrace_event_id(w, e, cfg, &task, arg_cnt);
+	if (utrace_id < 0)
+		utrace_id = cfg_id;
+	if (utrace_id_is_dyn(utrace_id)) {
+		json_kv_str(j, "utrace_id", utrace_dyn_name(utrace_id));
+	} else if (cfg->settings.id) {
 		json_kv_str(j, "utrace_id", cfg->settings.id);
 	} else {
 		char id_buf[16];

--- a/src/emit.c
+++ b/src/emit.c
@@ -4741,14 +4741,30 @@ static bool utrace_arg_for_event(const struct wevent *e, bool ret_filter, const 
 	return true;
 }
 
+static int utrace_render_env(char *buf, size_t buf_sz, const struct wevent *e,
+			     const struct wprof_task *t, enum utrace_env_ref ref)
+{
+	switch (ref) {
+	case UTRACE_ENV_TID:	return snprintf(buf, buf_sz, "%u", t->tid);
+	case UTRACE_ENV_PID:	return snprintf(buf, buf_sz, "%u", t->pid);
+	case UTRACE_ENV_PPID:	return snprintf(buf, buf_sz, "%u", t->ppid);
+	case UTRACE_ENV_COMM:	return snprintf(buf, buf_sz, "%s", t->comm);
+	case UTRACE_ENV_PCOMM:	return snprintf(buf, buf_sz, "%s", t->pcomm);
+	case UTRACE_ENV_CPU:	return snprintf(buf, buf_sz, "%d", e->cpu);
+	case UTRACE_ENV_NUMA:	return snprintf(buf, buf_sz, "%d", e->numa_node);
+	default:		return 0;
+	}
+}
+
 /*
  * Format a compiled template, substituting {arg_name} placeholders with actual
- * argument values. Only entry-side args (non-ret) are available for
- * substitution. Returns length written (like snprintf).
+ * argument values and {env:...} ones with the event's capture context. Only
+ * entry-side args (non-ret) are available for substitution. Returns length
+ * written (like snprintf).
  */
 static int utrace_render_tmpl(char *buf, size_t buf_sz, struct wprof_data_hdr *hdr,
-			      const struct wevent *e, const struct utrace_tmpl_seg *segs, int seg_cnt,
-			      int arg_cnt)
+			      const struct wevent *e, const struct wprof_task *t,
+			      const struct utrace_tmpl_seg *segs, int seg_cnt, int arg_cnt)
 {
 	const s32 *arg_refs = (const s32 *)((const void *)e + WEVENT_SZ(utrace));
 	size_t pos = 0;
@@ -4759,6 +4775,8 @@ static int utrace_render_tmpl(char *buf, size_t buf_sz, struct wprof_data_hdr *h
 
 		if (seg->type == UTRACE_TMPL_SEG_LIT) {
 			n = snprintf(buf + pos, buf_sz - pos, "%.*s", seg->lit.len, seg->lit.s);
+		} else if (seg->type == UTRACE_TMPL_SEG_ENV) {
+			n = utrace_render_env(buf + pos, buf_sz - pos, e, t, seg->env);
 		} else if (seg->arg.arg_idx < arg_cnt && arg_refs[seg->arg.arg_idx] >= 0) {
 			n = utrace_format_arg(buf + pos, buf_sz - pos, hdr, arg_refs[seg->arg.arg_idx],
 					      seg->arg.param);
@@ -4772,10 +4790,11 @@ static int utrace_render_tmpl(char *buf, size_t buf_sz, struct wprof_data_hdr *h
 }
 
 static int utrace_render_name(char *buf, size_t buf_sz, struct wprof_data_hdr *hdr,
-			      const struct wevent *e, const struct utrace_cfg *cfg, int arg_cnt)
+			      const struct wevent *e, const struct wprof_task *t,
+			      const struct utrace_cfg *cfg, int arg_cnt)
 {
 	if (cfg->settings.name_segs) {
-		return utrace_render_tmpl(buf, buf_sz, hdr, e, cfg->settings.name_segs,
+		return utrace_render_tmpl(buf, buf_sz, hdr, e, t, cfg->settings.name_segs,
 					  cfg->settings.name_seg_cnt, arg_cnt);
 	} else {
 		return snprintf(buf, buf_sz, "%s", utrace_probe_name(cfg));
@@ -4832,7 +4851,7 @@ static int utrace_event_id(struct worker_state *w, const struct wevent *e,
 	if (e->kind == EV_UTRACE_EXIT)
 		return utrace_span_pop(task_state(w, t), cfg_id);
 
-	utrace_render_tmpl(buf, sizeof(buf), w->dump_hdr, e, cfg->settings.id_segs,
+	utrace_render_tmpl(buf, sizeof(buf), w->dump_hdr, e, t, cfg->settings.id_segs,
 			   cfg->settings.id_seg_cnt, arg_cnt);
 	utrace_id = utrace_intern_id(buf);
 
@@ -4913,11 +4932,11 @@ static void emit_utrace_event(struct worker_state *w, const struct wevent *e)
 	emit_track_descrs(w, &task);
 	u64 track_uuid = ensure_utrace_thread_track(&task, utrace_id);
 
-	/* Format the event name: use name_tmpl on entry/instant, probe name on exit */
+	/* Format the event name: use name_tmpl unless it needs the entry-side args an exit lacks */
 	char name_buf[256];
 	const char *name;
-	if (e->kind != EV_UTRACE_EXIT && cfg->settings.name_segs) {
-		utrace_render_name(name_buf, sizeof(name_buf), hdr, e, cfg, arg_cnt);
+	if (cfg->settings.name_segs && (e->kind != EV_UTRACE_EXIT || !cfg->settings.name_has_args)) {
+		utrace_render_name(name_buf, sizeof(name_buf), hdr, e, &task, cfg, arg_cnt);
 		name = name_buf;
 	} else {
 		name = utrace_probe_name(arg_cfg);
@@ -4999,8 +5018,8 @@ static void emit_utrace_json(struct worker_state *w, const struct wevent *e)
 	}
 	char name_buf[256];
 	const char *name;
-	if (e->kind != EV_UTRACE_EXIT && cfg->settings.name_segs) {
-		utrace_render_name(name_buf, sizeof(name_buf), hdr, e, cfg, arg_cnt);
+	if (cfg->settings.name_segs && (e->kind != EV_UTRACE_EXIT || !cfg->settings.name_has_args)) {
+		utrace_render_name(name_buf, sizeof(name_buf), hdr, e, &task, cfg, arg_cnt);
 		name = name_buf;
 	} else {
 		name = utrace_probe_name(arg_cfg);

--- a/src/emit.c
+++ b/src/emit.c
@@ -233,6 +233,11 @@ static bool utrace_track_equal_fn(long a, long b, void *ctx)
 	return strcmp(x->name, y->name) == 0;
 }
 
+static struct hashmap *utrace_flow_ids;		/* rendered flow key -> flow id */
+static u64 utrace_flow_next_id = 1;
+
+#define UTRACE_FLOW_UUID(n) (((u64)0xF7 << 56) | (n))
+
 /*
  * Per (pmu_idx, cpu) snapshot of the previous PMU sample's absolute counter
  * values, so each sample reports the delta since the previous sample of the same
@@ -527,6 +532,10 @@ int init_emit(struct worker_state *w)
 
 	utrace_track_ids = hashmap__new(utrace_track_hash_fn, utrace_track_equal_fn, NULL);
 	if (!utrace_track_ids)
+		return -ENOMEM;
+
+	utrace_flow_ids = hashmap__new(str_hash_fn, str_equal_fn, NULL);
+	if (!utrace_flow_ids)
 		return -ENOMEM;
 
 	cur_wpb_writer = w->wpb_writer;
@@ -4686,6 +4695,18 @@ static u32 utrace_intern_track(enum utrace_scope scope, u32 scope_id, const char
 	return utrace_track_next_id++;
 }
 
+static u64 utrace_flow_id(const char *key)
+{
+	long id;
+
+	if (hashmap__find(utrace_flow_ids, key, &id))
+		return id;
+
+	id = UTRACE_FLOW_UUID(utrace_flow_next_id++);
+	hashmap__add(utrace_flow_ids, strdup(key), id);
+	return id;
+}
+
 static u32 utrace_scope_id(enum utrace_scope scope, const struct wprof_task *t, const struct wevent *e)
 {
 	switch (scope) {
@@ -4877,6 +4898,17 @@ static int utrace_render_name(char *buf, size_t buf_sz, struct wprof_data_hdr *h
 	}
 }
 
+static bool utrace_render_flow(char *buf, size_t buf_sz, struct wprof_data_hdr *hdr,
+			       const struct wevent *e, const struct wprof_task *t,
+			       const struct utrace_cfg *cfg, int arg_cnt)
+{
+	if (!cfg->settings.flow_segs || e->kind == EV_UTRACE_EXIT)
+		return false;
+	utrace_render_tmpl(buf, buf_sz, hdr, e, t, cfg->settings.flow_segs,
+			   cfg->settings.flow_seg_cnt, arg_cnt);
+	return true;
+}
+
 static void utrace_span_push(struct task_state *st, u32 cfg_id, u32 utrace_id)
 {
 	if (st->utspan_cnt == st->utspan_cap) {
@@ -5025,12 +5057,19 @@ static void emit_utrace_event(struct worker_state *w, const struct wevent *e)
 
 	u32 stack_id = (env.requested_stack_traces & ST_UTRACE) ? e->utrace.utrace_stack_id : 0;
 
+	char flow_buf[256];
+	u64 flow_id = 0;
+	if (utrace_render_flow(flow_buf, sizeof(flow_buf), hdr, e, &task, cfg, arg_cnt))
+		flow_id = utrace_flow_id(flow_buf);
+
 	switch (emit_kind) {
 	case EV_UTRACE_ENTRY:
 		emit_slice_begin(track_uuid, e->ts, iid_str(name_iid, name), IID_CAT_UTRACE) {
 			emit_utrace_args(w, e, arg_cfg, arg_cnt, ret_filter);
 			if (stack_id > 0)
 				emit_callstack(w, stack_id);
+			if (flow_id)
+				emit_flow_id(flow_id);
 		}
 		break;
 	case EV_UTRACE_EXIT:
@@ -5045,6 +5084,8 @@ static void emit_utrace_event(struct worker_state *w, const struct wevent *e)
 			emit_utrace_args(w, e, arg_cfg, arg_cnt, ret_filter);
 			if (stack_id > 0)
 				emit_callstack(w, stack_id);
+			if (flow_id)
+				emit_flow_id(flow_id);
 		}
 		break;
 	}
@@ -5103,6 +5144,10 @@ static void emit_utrace_json(struct worker_state *w, const struct wevent *e)
 		name = utrace_probe_name(arg_cfg);
 	}
 	json_kv_str(j, "name", name);
+
+	char flow_buf[256];
+	if (utrace_render_flow(flow_buf, sizeof(flow_buf), hdr, e, &task, cfg, arg_cnt))
+		json_kv_str(j, "flow_id", flow_buf);
 
 	/* Decode args from wevent trailing data */
 	const s32 *arg_refs = (const s32 *)((const void *)e + WEVENT_SZ(utrace));

--- a/src/protobuf.c
+++ b/src/protobuf.c
@@ -731,6 +731,21 @@ static void emit_metadata(struct wpb_writer *writer, struct wprof_data_hdr *hdr)
 		.val = wpb_cstr(ts),
 	};
 
+	/* persist the same information --replay-info prints in its extras section */
+	size_t extras_start = attr_cnt;
+	for (u64 i = 0; i < hdr->extra_cnt; i++) {
+		struct wprof_extra_param *e = wevent_extra_param(hdr, i);
+
+		if (e->kind == WEXTRA_METADATA || e->kind == WEXTRA_STATS ||
+		    e->kind == WEXTRA_STACK_CAPTURE)
+			continue;
+		attrs[attr_cnt] = (struct wpb_attr) {
+			.key = wpb_cstr(sfmt("extra.%zu", attr_cnt - extras_start)),
+			.val = wpb_cstr(extra_param_str(hdr, e)),
+		};
+		attr_cnt++;
+	}
+
 	wpb_emit_trace_attributes(writer, attrs, attr_cnt);
 	free(attrs);
 }

--- a/src/protobuf.c
+++ b/src/protobuf.c
@@ -740,7 +740,7 @@ static void emit_metadata(struct wpb_writer *writer, struct wprof_data_hdr *hdr)
 		    e->kind == WEXTRA_STACK_CAPTURE)
 			continue;
 		attrs[attr_cnt] = (struct wpb_attr) {
-			.key = wpb_cstr(sfmt("extra.%zu", attr_cnt - extras_start)),
+			.key = wpb_cstr(sfmt("extra-arg.%zu", attr_cnt - extras_start + 1)),
 			.val = wpb_cstr(extra_param_str(hdr, e)),
 		};
 		attr_cnt++;

--- a/src/utils.c
+++ b/src/utils.c
@@ -327,34 +327,50 @@ void file_pad(FILE *f, size_t align)
 	}
 }
 
-#define FMT_BUF_LEVELS 64
 #define FMT_BUF_LEN 1024
 
-static __thread char fmt_bufs[FMT_BUF_LEVELS][FMT_BUF_LEN];
-static __thread int fmt_buf_idx = 0;
+/*
+ * Buffers are allocated one at a time, so that growing the pool leaves every
+ * string handed out so far where it is. sfmt_reset() hands them out again.
+ */
+static __thread char **fmt_bufs;
+static __thread int fmt_buf_cnt;
+static __thread int fmt_buf_idx;
+
+static char *fmt_buf_next(void)
+{
+	if (fmt_buf_idx == fmt_buf_cnt) {
+		fmt_bufs = realloc(fmt_bufs, (fmt_buf_cnt + 1) * sizeof(*fmt_bufs));
+		fmt_bufs[fmt_buf_cnt++] = malloc(FMT_BUF_LEN);
+	}
+	return fmt_bufs[fmt_buf_idx++];
+}
 
 __attribute__((format(printf, 1, 2)))
 const char *sfmt(const char *fmt, ...)
 {
+	char *fmt_buf = fmt_buf_next();
 	va_list ap;
-	char *fmt_buf = fmt_bufs[fmt_buf_idx % FMT_BUF_LEVELS];
 
 	va_start(ap, fmt);
 	(void)vsnprintf(fmt_buf, FMT_BUF_LEN, fmt, ap);
 	va_end(ap);
 
-	fmt_buf_idx++;
 	return fmt_buf;
 }
 
 const char *vsfmt(const char *fmt, va_list ap)
 {
-	char *fmt_buf = fmt_bufs[fmt_buf_idx % FMT_BUF_LEVELS];
+	char *fmt_buf = fmt_buf_next();
 
 	(void)vsnprintf(fmt_buf, FMT_BUF_LEN, fmt, ap);
 
-	fmt_buf_idx++;
 	return fmt_buf;
+}
+
+void sfmt_reset(void)
+{
+	fmt_buf_idx = 0;
 }
 
 int parse_int_from_file(const char *file, const char *fmt, void *val)

--- a/src/utils.c
+++ b/src/utils.c
@@ -327,7 +327,7 @@ void file_pad(FILE *f, size_t align)
 	}
 }
 
-#define FMT_BUF_LEVELS 16
+#define FMT_BUF_LEVELS 64
 #define FMT_BUF_LEN 1024
 
 static __thread char fmt_bufs[FMT_BUF_LEVELS][FMT_BUF_LEN];

--- a/src/utils.h
+++ b/src/utils.h
@@ -184,6 +184,7 @@ static inline const char *fmt_timestamp_ns(u64 realtime_ns)
 	return buf;
 }
 const char *vsfmt(const char *fmt, va_list ap);
+void sfmt_reset(void);
 int parse_int_from_file(const char *file, const char *fmt, void *val);
 int parse_str_from_file(const char *file, char *buf, size_t buf_sz);
 int parse_cpu_mask(const char *fcpu, bool **mask, int *mask_sz);

--- a/src/utrace.c
+++ b/src/utrace.c
@@ -2158,6 +2158,14 @@ static void clone_cfg_with_pid(const struct utrace_cfg *src,
 	dst->settings.id_seg_cnt = 0;
 	dst->settings.flow_segs = NULL;
 	dst->settings.flow_seg_cnt = 0;
+	if (src->settings.ann_cnt) {
+		dst->settings.anns = malloc(src->settings.ann_cnt * sizeof(*dst->settings.anns));
+		for (int i = 0; i < src->settings.ann_cnt; i++) {
+			dst->settings.anns[i] = src->settings.anns[i];
+			dst->settings.anns[i].segs = NULL;
+			dst->settings.anns[i].seg_cnt = 0;
+		}
+	}
 
 	if (src->type == UTRACE_SPAN) {
 		enum utrace_pid_discovery d = cfg_pid_discovery(src);

--- a/src/utrace.c
+++ b/src/utrace.c
@@ -1746,13 +1746,9 @@ static int utrace_augment_args(void)
 			return err;
 	}
 
-	/* compile name format templates after all arg types/names are resolved */
-	for (int i = 0; i < env.utrace_cfg_cnt; i++) {
-		struct utrace_cfg *cfg = &env.utrace_cfgs[i];
-
-		if (cfg->settings.name_tmpl)
-			utrace_cfg_compile_name(cfg);
-	}
+	/* compile name/id format templates after all arg types/names are resolved */
+	for (int i = 0; i < env.utrace_cfg_cnt; i++)
+		utrace_cfg_compile_tmpls(&env.utrace_cfgs[i]);
 	return 0;
 }
 
@@ -2155,6 +2151,8 @@ static void clone_cfg_with_pid(const struct utrace_cfg *src,
 	*dst = *src;
 	dst->settings.name_segs = NULL;
 	dst->settings.name_seg_cnt = 0;
+	dst->settings.id_segs = NULL;
+	dst->settings.id_seg_cnt = 0;
 
 	if (src->type == UTRACE_SPAN) {
 		enum utrace_pid_discovery d = cfg_pid_discovery(src);

--- a/src/utrace.c
+++ b/src/utrace.c
@@ -2156,6 +2156,8 @@ static void clone_cfg_with_pid(const struct utrace_cfg *src,
 	dst->settings.name_seg_cnt = 0;
 	dst->settings.id_segs = NULL;
 	dst->settings.id_seg_cnt = 0;
+	dst->settings.flow_segs = NULL;
+	dst->settings.flow_seg_cnt = 0;
 
 	if (src->type == UTRACE_SPAN) {
 		enum utrace_pid_discovery d = cfg_pid_discovery(src);

--- a/src/utrace.c
+++ b/src/utrace.c
@@ -1746,9 +1746,12 @@ static int utrace_augment_args(void)
 			return err;
 	}
 
-	/* compile name/id format templates after all arg types/names are resolved */
-	for (int i = 0; i < env.utrace_cfg_cnt; i++)
-		utrace_cfg_compile_tmpls(&env.utrace_cfgs[i]);
+	/* compile name/id templates after all arg types/names are resolved */
+	for (int i = 0; i < env.utrace_cfg_cnt; i++) {
+		int err = utrace_cfg_compile_tmpls(&env.utrace_cfgs[i]);
+		if (err)
+			return err;
+	}
 	return 0;
 }
 

--- a/src/utrace.c
+++ b/src/utrace.c
@@ -1750,7 +1750,7 @@ static int utrace_augment_args(void)
 	for (int i = 0; i < env.utrace_cfg_cnt; i++) {
 		struct utrace_cfg *cfg = &env.utrace_cfgs[i];
 
-		if (cfg->settings.name_fmt)
+		if (cfg->settings.name_tmpl)
 			utrace_cfg_compile_name(cfg);
 	}
 	return 0;

--- a/src/utrace_cfg.c
+++ b/src/utrace_cfg.c
@@ -718,6 +718,12 @@ static int parse_settings(struct sview orig, struct sview def, struct utrace_set
 			err = sv_consume_str_literal(orig, sv_trim(sv_consume_left(tok, 5)), "name", &settings->name_tmpl);
 			if (err)
 				return err;
+		} else if (sv_starts_with(tok, "flow:")) {
+			if (settings->flow_tmpl)
+				return utrace_err(orig, tok, "duplicate 'flow' setting\n");
+			err = sv_consume_str_literal(orig, sv_trim(sv_consume_left(tok, 5)), "flow", &settings->flow_tmpl);
+			if (err)
+				return err;
 		} else {
 			return utrace_err(orig, tok, "unknown setting\n");
 		}
@@ -869,11 +875,11 @@ static bool tmpl_is_dynamic(const struct utrace_tmpl_seg *segs, int seg_cnt)
 }
 
 /*
- * Compile the cfg's name and id templates into segments, resolving placeholders
- * against the (entry-side) arg params. Runs both at capture (after arg types are
- * resolved) and on replay (after re-parsing the persisted definition), so that
- * replayed traces reproduce templated event names and track ids rather than the
- * bare probe name.
+ * Compile the cfg's name, id and flow templates into segments, resolving
+ * placeholders against the (entry-side) arg params. Runs both at capture (after
+ * arg types are resolved) and on replay (after re-parsing the persisted
+ * definition), so that replayed traces reproduce templated event names, track
+ * ids and flows rather than the bare probe name.
  *
  * An id template that substitutes nothing renders to itself, so it keeps
  * id_segs NULL and emit keeps using the id string as is.
@@ -907,6 +913,12 @@ int utrace_cfg_compile_tmpls(struct utrace_cfg *cfg)
 			cfg->settings.id_segs = NULL;
 			cfg->settings.id_seg_cnt = 0;
 		}
+	}
+	if (cfg->settings.flow_tmpl) {
+		err = utrace_compile_tmpl(cfg->settings.flow_tmpl, params, param_cnt,
+					  &cfg->settings.flow_segs, &cfg->settings.flow_seg_cnt);
+		if (err)
+			return err;
 	}
 	return 0;
 }
@@ -1329,29 +1341,33 @@ static void format_setting_value(struct sbuf *sb, const char *val)
 
 static void format_settings(const struct utrace_settings *s, struct sbuf *sb)
 {
-	if (!s->id && !s->name_tmpl && s->scope == UTRACE_SCOPE_THREAD)
-		return;
-
-	sbuf_appendf(sb, " | ");
 	bool first = true;
+
 	if (s->id) {
+		sbuf_appendf(sb, first ? " | " : ", ");
 		sbuf_appendf(sb, "id:");
 		format_setting_value(sb, s->id);
 		first = false;
 	}
 	if (s->scope != UTRACE_SCOPE_THREAD) {
-		if (!first)
-			sbuf_appendf(sb, ", ");
+		sbuf_appendf(sb, first ? " | " : ", ");
 		sbuf_appendf(sb, "scope:%s", scope_str(s->scope));
 		first = false;
 	}
 	if (s->name_tmpl) {
-		if (!first)
-			sbuf_appendf(sb, ", ");
+		sbuf_appendf(sb, first ? " | " : ", ");
 		sbuf_appendf(sb, "name:");
 		format_setting_value(sb, s->name_tmpl);
+		first = false;
 	}
-	sbuf_appendf(sb, " |");
+	if (s->flow_tmpl) {
+		sbuf_appendf(sb, first ? " | " : ", ");
+		sbuf_appendf(sb, "flow:");
+		format_setting_value(sb, s->flow_tmpl);
+		first = false;
+	}
+	if (!first)
+		sbuf_appendf(sb, " |");
 }
 
 void utrace_cfg_format(const struct utrace_cfg *cfg, struct sbuf *sb)

--- a/src/utrace_cfg.c
+++ b/src/utrace_cfg.c
@@ -663,6 +663,25 @@ static int sv_consume_str_literal(struct sview orig, struct sview tok, const cha
 	return 0;
 }
 
+static const struct {
+	const char *name;
+	enum utrace_scope scope;
+} scope_table[] = {
+	{ "thread",  UTRACE_SCOPE_THREAD },
+	{ "process", UTRACE_SCOPE_PROCESS },
+	{ "cpu",     UTRACE_SCOPE_CPU },
+	{ "global",  UTRACE_SCOPE_GLOBAL },
+};
+
+static const char *scope_str(enum utrace_scope scope)
+{
+	for (int i = 0; i < ARRAY_SIZE(scope_table); i++) {
+		if (scope_table[i].scope == scope)
+			return scope_table[i].name;
+	}
+	return "???";
+}
+
 /* parse settings block: "id:value, name:'format {arg}'" */
 static int parse_settings(struct sview orig, struct sview def, struct utrace_settings *settings)
 {
@@ -682,6 +701,19 @@ static int parse_settings(struct sview orig, struct sview def, struct utrace_set
 			err = sv_consume_str_literal(orig, sv_trim(sv_consume_left(tok, 3)), "id", &settings->id);
 			if (err)
 				return err;
+		} else if (sv_starts_with(tok, "scope:")) {
+			struct sview val = sv_trim(sv_consume_left(tok, 6));
+			int i;
+
+			if (settings->scope)
+				return utrace_err(orig, tok, "duplicate 'scope' setting\n");
+			for (i = 0; i < ARRAY_SIZE(scope_table); i++) {
+				if (sv_eq(val, scope_table[i].name))
+					break;
+			}
+			if (i == ARRAY_SIZE(scope_table))
+				return utrace_err(orig, val, "unknown scope '%.*s'\n", val.len, val.s);
+			settings->scope = scope_table[i].scope;
 		} else if (sv_starts_with(tok, "name:")) {
 			err = sv_consume_str_literal(orig, sv_trim(sv_consume_left(tok, 5)), "name", &settings->name_tmpl);
 			if (err)
@@ -1102,9 +1134,13 @@ int utrace_cfg_parse(const char *def)
 {
 	env.utrace_cfgs = realloc(env.utrace_cfgs, (env.utrace_cfg_cnt + 1) * sizeof(*env.utrace_cfgs));
 
-	int err = parse_cfg(sv_new(def), &env.utrace_cfgs[env.utrace_cfg_cnt]);
+	struct utrace_cfg *cfg = &env.utrace_cfgs[env.utrace_cfg_cnt];
+	int err = parse_cfg(sv_new(def), cfg);
+
 	if (err)
 		return err;
+	if (cfg->settings.scope == UTRACE_SCOPE_UNSET)
+		cfg->settings.scope = UTRACE_SCOPE_THREAD;
 	env.utrace_cfg_cnt++;
 	return 0;
 }
@@ -1293,7 +1329,7 @@ static void format_setting_value(struct sbuf *sb, const char *val)
 
 static void format_settings(const struct utrace_settings *s, struct sbuf *sb)
 {
-	if (!s->id && !s->name_tmpl)
+	if (!s->id && !s->name_tmpl && s->scope == UTRACE_SCOPE_THREAD)
 		return;
 
 	sbuf_appendf(sb, " | ");
@@ -1301,6 +1337,12 @@ static void format_settings(const struct utrace_settings *s, struct sbuf *sb)
 	if (s->id) {
 		sbuf_appendf(sb, "id:");
 		format_setting_value(sb, s->id);
+		first = false;
+	}
+	if (s->scope != UTRACE_SCOPE_THREAD) {
+		if (!first)
+			sbuf_appendf(sb, ", ");
+		sbuf_appendf(sb, "scope:%s", scope_str(s->scope));
 		first = false;
 	}
 	if (s->name_tmpl) {

--- a/src/utrace_cfg.c
+++ b/src/utrace_cfg.c
@@ -683,7 +683,7 @@ static int parse_settings(struct sview orig, struct sview def, struct utrace_set
 			if (err)
 				return err;
 		} else if (sv_starts_with(tok, "name:")) {
-			err = sv_consume_str_literal(orig, sv_trim(sv_consume_left(tok, 5)), "name", &settings->name_fmt);
+			err = sv_consume_str_literal(orig, sv_trim(sv_consume_left(tok, 5)), "name", &settings->name_tmpl);
 			if (err)
 				return err;
 		} else {
@@ -694,38 +694,38 @@ static int parse_settings(struct sview orig, struct sview def, struct utrace_set
 	return 0;
 }
 
-void utrace_compile_fmt(const char *fmt, const struct utrace_param *params, int param_cnt,
-			       struct utrace_fmt_seg **out_segs, int *out_seg_cnt)
+void utrace_compile_tmpl(const char *tmpl, const struct utrace_param *params, int param_cnt,
+			 struct utrace_tmpl_seg **out_segs, int *out_seg_cnt)
 {
-	struct utrace_fmt_seg *segs = NULL;
+	struct utrace_tmpl_seg *segs = NULL;
 	int seg_cnt = 0;
 
-	while (*fmt) {
-		if (*fmt != '{') {
+	while (*tmpl) {
+		if (*tmpl != '{') {
 			/* start of a literal run */
-			const char *start = fmt;
-			while (*fmt && *fmt != '{')
-				fmt++;
+			const char *start = tmpl;
+			while (*tmpl && *tmpl != '{')
+				tmpl++;
 			segs = realloc(segs, (seg_cnt + 1) * sizeof(*segs));
-			segs[seg_cnt].type = UTRACE_FMT_SEG_LIT;
+			segs[seg_cnt].type = UTRACE_TMPL_SEG_LIT;
 			segs[seg_cnt].lit.s = start;
-			segs[seg_cnt].lit.len = fmt - start;
+			segs[seg_cnt].lit.len = tmpl - start;
 			seg_cnt++;
 			continue;
 		}
 
-		const char *close = strchr(fmt + 1, '}');
+		const char *close = strchr(tmpl + 1, '}');
 		if (!close) {
 			/* unterminated '{' — emit rest as literal */
 			segs = realloc(segs, (seg_cnt + 1) * sizeof(*segs));
-			segs[seg_cnt].type = UTRACE_FMT_SEG_LIT;
-			segs[seg_cnt].lit.s = fmt;
-			segs[seg_cnt].lit.len = strlen(fmt);
+			segs[seg_cnt].type = UTRACE_TMPL_SEG_LIT;
+			segs[seg_cnt].lit.s = tmpl;
+			segs[seg_cnt].lit.len = strlen(tmpl);
 			seg_cnt++;
 			break;
 		}
 
-		int name_len = close - fmt - 1;
+		int name_len = close - tmpl - 1;
 
 		/* try to resolve placeholder against entry-side ARG params */
 		int arg_idx = 0;
@@ -742,13 +742,13 @@ void utrace_compile_fmt(const char *fmt, const struct utrace_param *params, int 
 
 			bool name_match = p->arg.name &&
 				strlen(p->arg.name) == name_len &&
-				strncmp(p->arg.name, fmt + 1, name_len) == 0;
+				strncmp(p->arg.name, tmpl + 1, name_len) == 0;
 			bool auto_match = strlen(auto_name) == name_len &&
-				strncmp(auto_name, fmt + 1, name_len) == 0;
+				strncmp(auto_name, tmpl + 1, name_len) == 0;
 
 			if (name_match || auto_match) {
 				segs = realloc(segs, (seg_cnt + 1) * sizeof(*segs));
-				segs[seg_cnt].type = UTRACE_FMT_SEG_ARG;
+				segs[seg_cnt].type = UTRACE_TMPL_SEG_ARG;
 				segs[seg_cnt].arg.arg_idx = arg_idx;
 				segs[seg_cnt].arg.param = p;
 				seg_cnt++;
@@ -761,13 +761,13 @@ void utrace_compile_fmt(const char *fmt, const struct utrace_param *params, int 
 		if (!matched) {
 			/* unmatched placeholder — emit as literal including braces */
 			segs = realloc(segs, (seg_cnt + 1) * sizeof(*segs));
-			segs[seg_cnt].type = UTRACE_FMT_SEG_LIT;
-			segs[seg_cnt].lit.s = fmt;
-			segs[seg_cnt].lit.len = close - fmt + 1;
+			segs[seg_cnt].type = UTRACE_TMPL_SEG_LIT;
+			segs[seg_cnt].lit.s = tmpl;
+			segs[seg_cnt].lit.len = close - tmpl + 1;
 			seg_cnt++;
 		}
 
-		fmt = close + 1;
+		tmpl = close + 1;
 	}
 
 	*out_segs = segs;
@@ -792,8 +792,8 @@ void utrace_cfg_compile_name(struct utrace_cfg *cfg)
 		params = cfg->params;
 		param_cnt = cfg->param_cnt;
 	}
-	utrace_compile_fmt(cfg->settings.name_fmt, params, param_cnt,
-			   &cfg->settings.name_segs, &cfg->settings.name_seg_cnt);
+	utrace_compile_tmpl(cfg->settings.name_tmpl, params, param_cnt,
+			    &cfg->settings.name_segs, &cfg->settings.name_seg_cnt);
 }
 
 static int parse_probe_def(struct sview orig, struct sview def, struct utrace_cfg *cfg)
@@ -1210,7 +1210,7 @@ static void format_setting_value(struct sbuf *sb, const char *val)
 
 static void format_settings(const struct utrace_settings *s, struct sbuf *sb)
 {
-	if (!s->id && !s->name_fmt)
+	if (!s->id && !s->name_tmpl)
 		return;
 
 	sbuf_appendf(sb, " | ");
@@ -1220,11 +1220,11 @@ static void format_settings(const struct utrace_settings *s, struct sbuf *sb)
 		format_setting_value(sb, s->id);
 		first = false;
 	}
-	if (s->name_fmt) {
+	if (s->name_tmpl) {
 		if (!first)
 			sbuf_appendf(sb, ", ");
 		sbuf_appendf(sb, "name:");
-		format_setting_value(sb, s->name_fmt);
+		format_setting_value(sb, s->name_tmpl);
 	}
 	sbuf_appendf(sb, " |");
 }

--- a/src/utrace_cfg.c
+++ b/src/utrace_cfg.c
@@ -694,10 +694,34 @@ static int parse_settings(struct sview orig, struct sview def, struct utrace_set
 	return 0;
 }
 
-void utrace_compile_tmpl(const char *tmpl, const struct utrace_param *params, int param_cnt,
-			 struct utrace_tmpl_seg **out_segs, int *out_seg_cnt)
+static const struct {
+	const char *name;
+	enum utrace_env_ref ref;
+} env_ref_table[] = {
+	{ "tid",   UTRACE_ENV_TID },
+	{ "pid",   UTRACE_ENV_PID },
+	{ "ppid",  UTRACE_ENV_PPID },
+	{ "comm",  UTRACE_ENV_COMM },
+	{ "pcomm", UTRACE_ENV_PCOMM },
+	{ "cpu",   UTRACE_ENV_CPU },
+	{ "numa",  UTRACE_ENV_NUMA },
+};
+
+/* resolve the KEY of an {env:KEY} placeholder, -1 if there is no such key */
+static int parse_env_ref(struct sview key)
+{
+	for (int i = 0; i < ARRAY_SIZE(env_ref_table); i++) {
+		if (sv_eq(key, env_ref_table[i].name))
+			return env_ref_table[i].ref;
+	}
+	return -1;
+}
+
+int utrace_compile_tmpl(const char *tmpl, const struct utrace_param *params, int param_cnt,
+			struct utrace_tmpl_seg **out_segs, int *out_seg_cnt)
 {
 	struct utrace_tmpl_seg *segs = NULL;
+	const char *orig = tmpl;
 	int seg_cnt = 0;
 
 	while (*tmpl) {
@@ -726,6 +750,24 @@ void utrace_compile_tmpl(const char *tmpl, const struct utrace_param *params, in
 		}
 
 		int name_len = close - tmpl - 1;
+		struct sview name = sv(tmpl + 1, name_len);
+
+		if (sv_starts_with(name, "env:")) {
+			struct sview key = sv_consume_left(name, 4);
+			int ref = parse_env_ref(key);
+
+			if (ref < 0) {
+				return utrace_err(sv_new(orig), sv(tmpl, close - tmpl + 1),
+						  "unknown environment reference '%.*s'\n",
+						  key.len, key.s);
+			}
+			segs = realloc(segs, (seg_cnt + 1) * sizeof(*segs));
+			segs[seg_cnt].type = UTRACE_TMPL_SEG_ENV;
+			segs[seg_cnt].env = ref;
+			seg_cnt++;
+			tmpl = close + 1;
+			continue;
+		}
 
 		/* try to resolve placeholder against entry-side ARG params */
 		int arg_idx = 0;
@@ -772,12 +814,23 @@ void utrace_compile_tmpl(const char *tmpl, const struct utrace_param *params, in
 
 	*out_segs = segs;
 	*out_seg_cnt = seg_cnt;
+	return 0;
 }
 
 static bool tmpl_has_args(const struct utrace_tmpl_seg *segs, int seg_cnt)
 {
 	for (int i = 0; i < seg_cnt; i++) {
 		if (segs[i].type == UTRACE_TMPL_SEG_ARG)
+			return true;
+	}
+	return false;
+}
+
+/* whether a template renders per event, rather than to one fixed string */
+static bool tmpl_is_dynamic(const struct utrace_tmpl_seg *segs, int seg_cnt)
+{
+	for (int i = 0; i < seg_cnt; i++) {
+		if (segs[i].type != UTRACE_TMPL_SEG_LIT)
 			return true;
 	}
 	return false;
@@ -793,10 +846,10 @@ static bool tmpl_has_args(const struct utrace_tmpl_seg *segs, int seg_cnt)
  * An id template that substitutes nothing renders to itself, so it keeps
  * id_segs NULL and emit keeps using the id string as is.
  */
-void utrace_cfg_compile_tmpls(struct utrace_cfg *cfg)
+int utrace_cfg_compile_tmpls(struct utrace_cfg *cfg)
 {
 	const struct utrace_param *params;
-	int param_cnt;
+	int param_cnt, err;
 	if (cfg->type == UTRACE_SPAN) {
 		params = cfg->span.entry->params;
 		param_cnt = cfg->span.entry->param_cnt;
@@ -805,18 +858,25 @@ void utrace_cfg_compile_tmpls(struct utrace_cfg *cfg)
 		param_cnt = cfg->param_cnt;
 	}
 	if (cfg->settings.name_tmpl) {
-		utrace_compile_tmpl(cfg->settings.name_tmpl, params, param_cnt,
-				    &cfg->settings.name_segs, &cfg->settings.name_seg_cnt);
+		err = utrace_compile_tmpl(cfg->settings.name_tmpl, params, param_cnt,
+					  &cfg->settings.name_segs, &cfg->settings.name_seg_cnt);
+		if (err)
+			return err;
+		cfg->settings.name_has_args = tmpl_has_args(cfg->settings.name_segs,
+							    cfg->settings.name_seg_cnt);
 	}
 	if (cfg->settings.id) {
-		utrace_compile_tmpl(cfg->settings.id, params, param_cnt,
-				    &cfg->settings.id_segs, &cfg->settings.id_seg_cnt);
-		if (!tmpl_has_args(cfg->settings.id_segs, cfg->settings.id_seg_cnt)) {
+		err = utrace_compile_tmpl(cfg->settings.id, params, param_cnt,
+					  &cfg->settings.id_segs, &cfg->settings.id_seg_cnt);
+		if (err)
+			return err;
+		if (!tmpl_is_dynamic(cfg->settings.id_segs, cfg->settings.id_seg_cnt)) {
 			free(cfg->settings.id_segs);
 			cfg->settings.id_segs = NULL;
 			cfg->settings.id_seg_cnt = 0;
 		}
 	}
+	return 0;
 }
 
 static int parse_probe_def(struct sview orig, struct sview def, struct utrace_cfg *cfg)

--- a/src/utrace_cfg.c
+++ b/src/utrace_cfg.c
@@ -724,6 +724,28 @@ static int parse_settings(struct sview orig, struct sview def, struct utrace_set
 			err = sv_consume_str_literal(orig, sv_trim(sv_consume_left(tok, 5)), "flow", &settings->flow_tmpl);
 			if (err)
 				return err;
+		} else if (sv_starts_with(tok, "ann:")) {
+			struct sview val;
+			struct sview name = sv_trim(sv_split(sv_consume_left(tok, 4), "=", &val));
+
+			if (sv_is_empty(val))
+				return utrace_err(orig, tok, "ann setting must be ann:NAME=VALUE\n");
+			if (sv_is_empty(name))
+				return utrace_err(orig, tok, "empty annotation name\n");
+			for (int i = 0; i < settings->ann_cnt; i++) {
+				if (sv_eq(name, settings->anns[i].name))
+					return utrace_err(orig, name, "duplicate annotation '%.*s'\n", name.len, name.s);
+			}
+
+			settings->anns = realloc(settings->anns, (settings->ann_cnt + 1) * sizeof(*settings->anns));
+			struct utrace_ann *ann = &settings->anns[settings->ann_cnt];
+
+			memset(ann, 0, sizeof(*ann));
+			ann->name = sv_strdup(name);
+			err = sv_consume_str_literal(orig, sv_trim(sv_consume_left(val, 1)), ann->name, &ann->tmpl);
+			if (err)
+				return err;
+			settings->ann_cnt++;
 		} else {
 			return utrace_err(orig, tok, "unknown setting\n");
 		}
@@ -919,6 +941,14 @@ int utrace_cfg_compile_tmpls(struct utrace_cfg *cfg)
 					  &cfg->settings.flow_segs, &cfg->settings.flow_seg_cnt);
 		if (err)
 			return err;
+	}
+	for (int i = 0; i < cfg->settings.ann_cnt; i++) {
+		struct utrace_ann *ann = &cfg->settings.anns[i];
+
+		err = utrace_compile_tmpl(ann->tmpl, params, param_cnt, &ann->segs, &ann->seg_cnt);
+		if (err)
+			return err;
+		ann->has_args = tmpl_has_args(ann->segs, ann->seg_cnt);
 	}
 	return 0;
 }
@@ -1364,6 +1394,12 @@ static void format_settings(const struct utrace_settings *s, struct sbuf *sb)
 		sbuf_appendf(sb, first ? " | " : ", ");
 		sbuf_appendf(sb, "flow:");
 		format_setting_value(sb, s->flow_tmpl);
+		first = false;
+	}
+	for (int i = 0; i < s->ann_cnt; i++) {
+		sbuf_appendf(sb, first ? " | " : ", ");
+		sbuf_appendf(sb, "ann:%s=", s->anns[i].name);
+		format_setting_value(sb, s->anns[i].tmpl);
 		first = false;
 	}
 	if (!first)

--- a/src/utrace_cfg.c
+++ b/src/utrace_cfg.c
@@ -774,14 +774,26 @@ void utrace_compile_tmpl(const char *tmpl, const struct utrace_param *params, in
 	*out_seg_cnt = seg_cnt;
 }
 
+static bool tmpl_has_args(const struct utrace_tmpl_seg *segs, int seg_cnt)
+{
+	for (int i = 0; i < seg_cnt; i++) {
+		if (segs[i].type == UTRACE_TMPL_SEG_ARG)
+			return true;
+	}
+	return false;
+}
+
 /*
- * Compile the cfg's name-format template into name_segs, resolving placeholders
+ * Compile the cfg's name and id templates into segments, resolving placeholders
  * against the (entry-side) arg params. Runs both at capture (after arg types are
  * resolved) and on replay (after re-parsing the persisted definition), so that
- * replayed traces reproduce templated event names rather than the bare probe
- * name.
+ * replayed traces reproduce templated event names and track ids rather than the
+ * bare probe name.
+ *
+ * An id template that substitutes nothing renders to itself, so it keeps
+ * id_segs NULL and emit keeps using the id string as is.
  */
-void utrace_cfg_compile_name(struct utrace_cfg *cfg)
+void utrace_cfg_compile_tmpls(struct utrace_cfg *cfg)
 {
 	const struct utrace_param *params;
 	int param_cnt;
@@ -792,8 +804,19 @@ void utrace_cfg_compile_name(struct utrace_cfg *cfg)
 		params = cfg->params;
 		param_cnt = cfg->param_cnt;
 	}
-	utrace_compile_tmpl(cfg->settings.name_tmpl, params, param_cnt,
-			    &cfg->settings.name_segs, &cfg->settings.name_seg_cnt);
+	if (cfg->settings.name_tmpl) {
+		utrace_compile_tmpl(cfg->settings.name_tmpl, params, param_cnt,
+				    &cfg->settings.name_segs, &cfg->settings.name_seg_cnt);
+	}
+	if (cfg->settings.id) {
+		utrace_compile_tmpl(cfg->settings.id, params, param_cnt,
+				    &cfg->settings.id_segs, &cfg->settings.id_seg_cnt);
+		if (!tmpl_has_args(cfg->settings.id_segs, cfg->settings.id_seg_cnt)) {
+			free(cfg->settings.id_segs);
+			cfg->settings.id_segs = NULL;
+			cfg->settings.id_seg_cnt = 0;
+		}
+	}
 }
 
 static int parse_probe_def(struct sview orig, struct sview def, struct utrace_cfg *cfg)

--- a/src/utrace_cfg.h
+++ b/src/utrace_cfg.h
@@ -184,7 +184,7 @@ struct utrace_tmpl_seg {
 	enum utrace_tmpl_seg_type type;
 	union {
 		struct {
-			const char *s;   /* points into the name_tmpl string */
+			const char *s;   /* points into the source template string */
 			int len;
 		} lit;
 		struct {
@@ -199,6 +199,8 @@ struct utrace_settings {
 	char *name_tmpl; /* template string for slice/instant name, NULL if unset */
 	struct utrace_tmpl_seg *name_segs; /* pre-compiled name template segments */
 	int name_seg_cnt;
+	struct utrace_tmpl_seg *id_segs; /* pre-compiled id segments, NULL unless id has placeholders */
+	int id_seg_cnt;
 };
 
 struct utrace_cfg {
@@ -362,7 +364,7 @@ static inline const char *utrace_arg_map_lookup(const struct utrace_arg_map *map
 
 void utrace_compile_tmpl(const char *tmpl, const struct utrace_param *params, int param_cnt,
 			 struct utrace_tmpl_seg **out_segs, int *out_seg_cnt);
-void utrace_cfg_compile_name(struct utrace_cfg *cfg);
+void utrace_cfg_compile_tmpls(struct utrace_cfg *cfg);
 void utrace_cfg_add_pid(struct utrace_cfg *cfg, int pid, enum utrace_pid_discovery discovery);
 int utrace_cfg_parse(const char *def);
 int utrace_cfg_parse_file(const char *path);

--- a/src/utrace_cfg.h
+++ b/src/utrace_cfg.h
@@ -178,6 +178,18 @@ struct utrace_param {
 enum utrace_tmpl_seg_type {
 	UTRACE_TMPL_SEG_LIT,  /* literal string segment */
 	UTRACE_TMPL_SEG_ARG,  /* argument substitution */
+	UTRACE_TMPL_SEG_ENV,  /* capture environment substitution */
+};
+
+/* what an {env:...} placeholder pulls from the event's capture context */
+enum utrace_env_ref {
+	UTRACE_ENV_TID,
+	UTRACE_ENV_PID,
+	UTRACE_ENV_PPID,
+	UTRACE_ENV_COMM,
+	UTRACE_ENV_PCOMM,
+	UTRACE_ENV_CPU,
+	UTRACE_ENV_NUMA,
 };
 
 struct utrace_tmpl_seg {
@@ -191,6 +203,7 @@ struct utrace_tmpl_seg {
 			int arg_idx;                /* positional index into entry-side arg_refs[] */
 			const struct utrace_param *param; /* the matched arg's full spec */
 		} arg;
+		enum utrace_env_ref env;
 	};
 };
 
@@ -199,6 +212,7 @@ struct utrace_settings {
 	char *name_tmpl; /* template string for slice/instant name, NULL if unset */
 	struct utrace_tmpl_seg *name_segs; /* pre-compiled name template segments */
 	int name_seg_cnt;
+	bool name_has_args; /* name template substitutes entry-side args, so exits can't render it */
 	struct utrace_tmpl_seg *id_segs; /* pre-compiled id segments, NULL unless id has placeholders */
 	int id_seg_cnt;
 };
@@ -362,9 +376,9 @@ static inline const char *utrace_arg_map_lookup(const struct utrace_arg_map *map
 	return NULL;
 }
 
-void utrace_compile_tmpl(const char *tmpl, const struct utrace_param *params, int param_cnt,
-			 struct utrace_tmpl_seg **out_segs, int *out_seg_cnt);
-void utrace_cfg_compile_tmpls(struct utrace_cfg *cfg);
+int utrace_compile_tmpl(const char *tmpl, const struct utrace_param *params, int param_cnt,
+			struct utrace_tmpl_seg **out_segs, int *out_seg_cnt);
+int utrace_cfg_compile_tmpls(struct utrace_cfg *cfg);
 void utrace_cfg_add_pid(struct utrace_cfg *cfg, int pid, enum utrace_pid_discovery discovery);
 int utrace_cfg_parse(const char *def);
 int utrace_cfg_parse_file(const char *path);

--- a/src/utrace_cfg.h
+++ b/src/utrace_cfg.h
@@ -207,8 +207,18 @@ struct utrace_tmpl_seg {
 	};
 };
 
+/* what a probe's tracks are grouped under */
+enum utrace_scope {
+	UTRACE_SCOPE_UNSET,	/* not given, resolved to thread scope once parsed */
+	UTRACE_SCOPE_THREAD,
+	UTRACE_SCOPE_PROCESS,
+	UTRACE_SCOPE_CPU,
+	UTRACE_SCOPE_GLOBAL,
+};
+
 struct utrace_settings {
 	char *id;        /* user-defined probe identifier, NULL if unset */
+	enum utrace_scope scope;
 	char *name_tmpl; /* template string for slice/instant name, NULL if unset */
 	struct utrace_tmpl_seg *name_segs; /* pre-compiled name template segments */
 	int name_seg_cnt;

--- a/src/utrace_cfg.h
+++ b/src/utrace_cfg.h
@@ -216,6 +216,14 @@ enum utrace_scope {
 	UTRACE_SCOPE_GLOBAL,
 };
 
+struct utrace_ann {
+	char *name;
+	char *tmpl;
+	struct utrace_tmpl_seg *segs;
+	int seg_cnt;
+	bool has_args; /* references entry-side args, so exits can't render it */
+};
+
 struct utrace_settings {
 	char *id;        /* user-defined probe identifier, NULL if unset */
 	enum utrace_scope scope;
@@ -228,6 +236,8 @@ struct utrace_settings {
 	char *flow_tmpl; /* template string for the flow key, NULL if unset */
 	struct utrace_tmpl_seg *flow_segs; /* pre-compiled flow template segments */
 	int flow_seg_cnt;
+	struct utrace_ann *anns; /* ann: settings, in definition order */
+	int ann_cnt;
 };
 
 struct utrace_cfg {

--- a/src/utrace_cfg.h
+++ b/src/utrace_cfg.h
@@ -225,6 +225,9 @@ struct utrace_settings {
 	bool name_has_args; /* name template substitutes entry-side args, so exits can't render it */
 	struct utrace_tmpl_seg *id_segs; /* pre-compiled id segments, NULL unless id has placeholders */
 	int id_seg_cnt;
+	char *flow_tmpl; /* template string for the flow key, NULL if unset */
+	struct utrace_tmpl_seg *flow_segs; /* pre-compiled flow template segments */
+	int flow_seg_cnt;
 };
 
 struct utrace_cfg {

--- a/src/utrace_cfg.h
+++ b/src/utrace_cfg.h
@@ -175,16 +175,16 @@ struct utrace_param {
 	};
 };
 
-enum utrace_fmt_seg_type {
-	UTRACE_FMT_SEG_LIT,  /* literal string segment */
-	UTRACE_FMT_SEG_ARG,  /* argument substitution */
+enum utrace_tmpl_seg_type {
+	UTRACE_TMPL_SEG_LIT,  /* literal string segment */
+	UTRACE_TMPL_SEG_ARG,  /* argument substitution */
 };
 
-struct utrace_fmt_seg {
-	enum utrace_fmt_seg_type type;
+struct utrace_tmpl_seg {
+	enum utrace_tmpl_seg_type type;
 	union {
 		struct {
-			const char *s;   /* points into name_fmt string */
+			const char *s;   /* points into the name_tmpl string */
 			int len;
 		} lit;
 		struct {
@@ -195,9 +195,9 @@ struct utrace_fmt_seg {
 };
 
 struct utrace_settings {
-	char *id;       /* user-defined probe identifier, NULL if unset */
-	char *name_fmt; /* format string for slice/instant name, NULL if unset */
-	struct utrace_fmt_seg *name_segs; /* pre-compiled name format segments */
+	char *id;        /* user-defined probe identifier, NULL if unset */
+	char *name_tmpl; /* template string for slice/instant name, NULL if unset */
+	struct utrace_tmpl_seg *name_segs; /* pre-compiled name template segments */
 	int name_seg_cnt;
 };
 
@@ -360,8 +360,8 @@ static inline const char *utrace_arg_map_lookup(const struct utrace_arg_map *map
 	return NULL;
 }
 
-void utrace_compile_fmt(const char *fmt, const struct utrace_param *params, int param_cnt,
-			struct utrace_fmt_seg **out_segs, int *out_seg_cnt);
+void utrace_compile_tmpl(const char *tmpl, const struct utrace_param *params, int param_cnt,
+			 struct utrace_tmpl_seg **out_segs, int *out_seg_cnt);
 void utrace_cfg_compile_name(struct utrace_cfg *cfg);
 void utrace_cfg_add_pid(struct utrace_cfg *cfg, int pid, enum utrace_pid_discovery discovery);
 int utrace_cfg_parse(const char *def);

--- a/src/wprof.c
+++ b/src/wprof.c
@@ -2253,7 +2253,7 @@ int main(int argc, char **argv)
 			case WEXTRA_UTRACE_DEF:
 				err = utrace_cfg_parse(val);
 				if (!err)
-					utrace_cfg_compile_tmpls(&env.utrace_cfgs[env.utrace_cfg_cnt - 1]);
+					err = utrace_cfg_compile_tmpls(&env.utrace_cfgs[env.utrace_cfg_cnt - 1]);
 				break;
 			/*
 			 * Emit (-e) options keep their CLI value if set, otherwise

--- a/src/wprof.c
+++ b/src/wprof.c
@@ -2255,7 +2255,7 @@ int main(int argc, char **argv)
 				if (!err) {
 					struct utrace_cfg *cfg = &env.utrace_cfgs[env.utrace_cfg_cnt - 1];
 
-					if (cfg->settings.name_fmt)
+					if (cfg->settings.name_tmpl)
 						utrace_cfg_compile_name(cfg);
 				}
 				break;

--- a/src/wprof.c
+++ b/src/wprof.c
@@ -1856,6 +1856,12 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
+	if (env.replay && env.utrace_cfg_cnt > 0) {
+		eprintf("--utrace (-U) is capture-time only and can't be used in replay mode (-R)!\n");
+		err = -EINVAL;
+		goto cleanup;
+	}
+
 	if (!env.replay && geteuid() != 0)
 		eprintf("WARNING: wprof is not running as root, data capture will most probably FAIL due to insufficient permissions!\n");
 

--- a/src/wprof.c
+++ b/src/wprof.c
@@ -2252,12 +2252,8 @@ int main(int argc, char **argv)
 				break;
 			case WEXTRA_UTRACE_DEF:
 				err = utrace_cfg_parse(val);
-				if (!err) {
-					struct utrace_cfg *cfg = &env.utrace_cfgs[env.utrace_cfg_cnt - 1];
-
-					if (cfg->settings.name_tmpl)
-						utrace_cfg_compile_name(cfg);
-				}
+				if (!err)
+					utrace_cfg_compile_tmpls(&env.utrace_cfgs[env.utrace_cfg_cnt - 1]);
 				break;
 			/*
 			 * Emit (-e) options keep their CLI value if set, otherwise


### PR DESCRIPTION
utrace probe definitions could already template an event's `name:`. This series turns the settings block into one small templating system: every setting that renders per event takes the same placeholders, and the set of settings grows to cover where an event lands, what it connects to, and what it carries.

## Settings

| Setting | Effect |
|---|---|
| `name:<template>` | event / slice name |
| `id:<template>` | names the track inside its scope; probes rendering equal ids share a track |
| `scope:thread\|process\|cpu\|global` | which container the track hangs under (default `thread`) |
| `flow:<template>` | joins events into a Perfetto flow; equal keys connect trace-wide |
| `ann:NAME=<template>` | annotates the event with a NAME key, repeatable |

Every template takes `{arg0}` / `{named_arg}` for captured arguments and `{env:tid|pid|ppid|comm|pcomm|cpu|numa}` for the context the probe fired in. Unlike arguments, `{env:...}` resolves on every event, including span exits.

## Examples

```bash
# one track per (thread, ring) instead of one for the probe
-U 'uspan:io_submit (arg:0.ring_id/name(ring)) | id:"ring {ring}" |'

# one track per futex, carrying every thread of the process that contends on it
-U 'tp:syscalls:sys_enter_futex (arg:uaddr/x) | scope:process, id:"futex {uaddr}" |'

# per-CPU workqueue tracks, with arrows from wherever each work item was queued
-U 'raw_tp:workqueue_queue_work (arg:work/x) | flow:"work {work}" |'
-U 'raw_tp:workqueue_execute_start (arg:work/x) ~~ raw_tp:workqueue_execute_end (arg:work/x) |
     scope:cpu, id:workqueue, flow:"work {work}", ann:worker="{env:comm}/{env:tid}" |'
```

## Semantics

**Tracks.** A `utrace_id` now identifies a track outright: the scope, the container within it, and the `id:` string (or the defining probe, when there is none) intern to one dense id that carries everything the track needs. Process scope parents to the process track, global scope to a new UTRACE folder under the session, and CPU scope to a per-CPU track under a new CPUS folder — a track kind of its own, so anything else wanting a per-CPU layout can reach for it.

A track wider than a thread can receive events from several threads at once, and Perfetto requires slices on one track to nest, so at those scopes an `id:` should name something never concurrent with itself — one track per request, queue or connection rather than one for the probe. Instants have no such restriction.

**Spans.** A span's exit carries only its own arguments, so it can't re-render an `id:` or `flow:` written against entry arguments, and its thread may have migrated meanwhile. An exit therefore takes the track its entry opened, matching exits to entries innermost-first for recursive spans. Flows attach at the entry; Perfetto draws the outgoing arrow from the end of the slice regardless. An exit with no entry to pair up with — a span already in flight when the capture or the replay window started — is emitted as a standalone instant on the probe's own track.

**Flows.** Flow keys share one trace-wide namespace, so equal keys join across probes, threads and processes. Narrowing is done in the template itself: prefix a literal, or add `{env:pid}` when a value like a pointer or an fd only identifies something within one process.

**Annotations.** Rendered annotations sit next to the captured argument annotations in Perfetto and under `anns` in JSON. One that references arguments is omitted on span exits; one built only from `{env:...}` renders on both sides of a span.

## Also in the series

- **Capture configuration in the trace.** A `.pb` carried the `-M` metadata but nothing about how the capture was configured. The extras that `--replay-info` prints are now emitted as Perfetto trace attributes, keyed `extra-arg.N` in definition order, so a trace can say which probes, filters and emit options produced it. Numbered because trace_processor keeps only the last value of a repeated key.

- **`sfmt()` no longer wraps.** It handed out one of 64 fixed buffers round-robin, so a caller formatting more strings than that before consuming them lost the earliest — which the extras loop above does past 32 extras. Buffers are now allocated one at a time and the pool grows, so a string keeps its place; `process_events()` reclaims the pool once per event, making that event the lifetime of anything `sfmt()` returns during emit.

- **`-U` is rejected in replay mode**, where probe definitions come from the capture rather than the command line.

- **`{env:tid}` renders idle threads as 0** rather than their synthetic negative tid printed unsigned.

JSON output gains `flow_id` (rendered flow key, on entry and instant events) and `anns`. `UTRACE.md` and `JSON_SCHEMA.md` are updated for all of the above.
